### PR TITLE
Update type and exports

### DIFF
--- a/src/families/algorand/types.ts
+++ b/src/families/algorand/types.ts
@@ -8,7 +8,7 @@ import type { TransactionCommon } from "../../types";
 export type AlgorandOperationMode = "send" | "optIn" | "claimReward" | "optOut";
 
 export interface AlgorandTransaction extends TransactionCommon {
-  family: FAMILIES.ALGORAND;
+  readonly family: FAMILIES.ALGORAND;
   mode: AlgorandOperationMode;
   fees?: BigNumber;
   assetId?: string;
@@ -16,7 +16,7 @@ export interface AlgorandTransaction extends TransactionCommon {
 }
 
 export interface RawAlgorandTransaction extends RawTransactionCommon {
-  family: FAMILIES.ALGORAND;
+  readonly family: FAMILIES.ALGORAND;
   mode: AlgorandOperationMode;
   fees?: string;
   assetId?: string;

--- a/src/families/bitcoin/types.ts
+++ b/src/families/bitcoin/types.ts
@@ -6,11 +6,11 @@ import type { RawTransactionCommon } from "../../rawTypes";
 import type { TransactionCommon } from "../../types";
 
 export interface BitcoinTransaction extends TransactionCommon {
-  family: FAMILIES.BITCOIN;
+  readonly family: FAMILIES.BITCOIN;
   feePerByte?: BigNumber;
 }
 
 export interface RawBitcoinTransaction extends RawTransactionCommon {
-  family: FAMILIES.BITCOIN;
+  readonly family: FAMILIES.BITCOIN;
   feePerByte?: string;
 }

--- a/src/families/cosmos/types.ts
+++ b/src/families/cosmos/types.ts
@@ -14,7 +14,7 @@ export type CosmosOperationMode =
   | "claimRewardCompound";
 
 export interface CosmosTransaction extends TransactionCommon {
-  family: FAMILIES.COSMOS;
+  readonly family: FAMILIES.COSMOS;
   mode: CosmosOperationMode;
   fees?: BigNumber;
   gas?: BigNumber;
@@ -22,7 +22,7 @@ export interface CosmosTransaction extends TransactionCommon {
 }
 
 export interface RawCosmosTransaction extends RawTransactionCommon {
-  family: FAMILIES.COSMOS;
+  readonly family: FAMILIES.COSMOS;
   mode: CosmosOperationMode;
   fees?: string;
   gas?: string;

--- a/src/families/crypto_org/types.ts
+++ b/src/families/crypto_org/types.ts
@@ -6,13 +6,13 @@ import type { RawTransactionCommon } from "../../rawTypes";
 import type { TransactionCommon } from "../../types";
 
 export interface CryptoOrgTransaction extends TransactionCommon {
-  family: FAMILIES.CRYPTO_ORG;
+  readonly family: FAMILIES.CRYPTO_ORG;
   mode: string;
   fees?: BigNumber;
 }
 
 export interface RawCryptoOrgTransaction extends RawTransactionCommon {
-  family: FAMILIES.CRYPTO_ORG;
+  readonly family: FAMILIES.CRYPTO_ORG;
   mode: string;
   fees?: string;
 }

--- a/src/families/ethereum/types.ts
+++ b/src/families/ethereum/types.ts
@@ -6,7 +6,7 @@ import type { RawTransactionCommon } from "../../rawTypes";
 import type { TransactionCommon } from "../../types";
 
 export interface EthereumTransaction extends TransactionCommon {
-  family: FAMILIES.ETHEREUM;
+  readonly family: FAMILIES.ETHEREUM;
   nonce?: number;
   data?: Buffer;
   gasPrice?: BigNumber;
@@ -14,7 +14,7 @@ export interface EthereumTransaction extends TransactionCommon {
 }
 
 export interface RawEthereumTransaction extends RawTransactionCommon {
-  family: FAMILIES.ETHEREUM;
+  readonly family: FAMILIES.ETHEREUM;
   nonce?: number;
   data?: string;
   gasPrice?: string;

--- a/src/families/polkadot/types.ts
+++ b/src/families/polkadot/types.ts
@@ -6,14 +6,14 @@ import type { RawTransactionCommon } from "../../rawTypes";
 import type { TransactionCommon } from "../../types";
 
 export interface PolkadotTransaction extends TransactionCommon {
-  family: FAMILIES.POLKADOT;
+  readonly family: FAMILIES.POLKADOT;
   mode: string;
   fee?: BigNumber;
   era?: number;
 }
 
 export interface RawPolkadotTransaction extends RawTransactionCommon {
-  family: FAMILIES.POLKADOT;
+  readonly family: FAMILIES.POLKADOT;
   mode: string;
   fee?: string;
   era?: number;

--- a/src/families/ripple/types.ts
+++ b/src/families/ripple/types.ts
@@ -6,13 +6,13 @@ import type { RawTransactionCommon } from "../../rawTypes";
 import type { TransactionCommon } from "../../types";
 
 export interface RippleTransaction extends TransactionCommon {
-  family: FAMILIES.RIPPLE;
+  readonly family: FAMILIES.RIPPLE;
   fee?: BigNumber;
   tag: number;
 }
 
 export interface RawRippleTransaction extends RawTransactionCommon {
-  family: FAMILIES.RIPPLE;
+  readonly family: FAMILIES.RIPPLE;
   fee?: string;
   tag: number;
 }

--- a/src/families/stellar/types.ts
+++ b/src/families/stellar/types.ts
@@ -6,14 +6,14 @@ import type { RawTransactionCommon } from "../../rawTypes";
 import type { TransactionCommon } from "../../types";
 
 export interface StellarTransaction extends TransactionCommon {
-  family: FAMILIES.STELLAR;
+  readonly family: FAMILIES.STELLAR;
   fees?: BigNumber;
   memoType?: string;
   memoValue?: string;
 }
 
 export interface RawStellarTransaction extends RawTransactionCommon {
-  family: FAMILIES.STELLAR;
+  readonly family: FAMILIES.STELLAR;
   fees?: string;
   memoType?: string;
   memoValue?: string;

--- a/src/families/tezos/types.ts
+++ b/src/families/tezos/types.ts
@@ -8,14 +8,14 @@ import type { TransactionCommon } from "../../types";
 export type TezosOperationMode = "send" | "delegate" | "undelegate";
 
 export interface TezosTransaction extends TransactionCommon {
-  family: FAMILIES.TEZOS;
+  readonly family: FAMILIES.TEZOS;
   mode: TezosOperationMode;
   fees?: BigNumber;
   gasLimit?: BigNumber;
 }
 
 export interface RawTezosTransaction extends RawTransactionCommon {
-  family: FAMILIES.TEZOS;
+  readonly family: FAMILIES.TEZOS;
   mode: TezosOperationMode;
   fees?: string;
   gasLimit?: string;

--- a/src/families/tron/types.ts
+++ b/src/families/tron/types.ts
@@ -13,14 +13,14 @@ export type TronOperationMode =
 export type TronResource = "BANDWIDTH" | "ENERGY";
 
 export interface TronTransaction extends TransactionCommon {
-  family: FAMILIES.TRON;
+  readonly family: FAMILIES.TRON;
   mode: TronOperationMode;
   resource?: TronResource;
   duration?: number;
 }
 
 export interface RawTronTransaction extends RawTransactionCommon {
-  family: FAMILIES.TRON;
+  readonly family: FAMILIES.TRON;
   mode: TronOperationMode;
   resource?: TronResource;
   duration?: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,15 @@ export * from "./types";
 export * from "./rawTypes";
 export * from "./families/ethereum/types";
 export * from "./families/bitcoin/types";
+export * from "./families/algorand/types";
+export * from "./families/cosmos/types";
+export * from "./families/crypto_org/types";
+export * from "./families/polkadot/types";
+export * from "./families/ripple/types";
+export * from "./families/stellar/types";
+export * from "./families/tezos/types";
+export * from "./families/tron/types";
+
 export { default as FAMILIES } from "./families/types";
 
 export { default as Mock } from "./mock";


### PR DESCRIPTION
Make `family` type property readonly and export all implemented families from the SDK root level