### PR TITLE
Use raw signed transaction instead of signed transaction

### DIFF
--- a/src/LedgerLivePlatformSDK/index.ts
+++ b/src/LedgerLivePlatformSDK/index.ts
@@ -7,12 +7,7 @@ import {
 import DeviceBridge from "../deviceBridge";
 import Logger from "../logger";
 import { RawAccount, RawSignedTransaction } from "../rawTypes";
-import {
-  deserializeAccount,
-  deserializeSignedTransaction,
-  serializeSignedTransaction,
-  serializeTransaction,
-} from "../serializers";
+import { deserializeAccount, serializeTransaction } from "../serializers";
 
 import type {
   Account,
@@ -24,7 +19,6 @@ import type {
   ExchangePayload,
   ExchangeType,
   FeesLevel,
-  SignedTransaction,
   Transaction,
   Transport,
 } from "../types";
@@ -156,39 +150,34 @@ export default class LedgerLivePlatformSDK {
    * @param {Transaction} transaction  - the transaction in the currency family-specific format
    * @param {SignTransactionParams} params - parameters for the sign modal
    *
-   * @returns {Promise<SignedTransaction>}
+   * @returns {Promise<RawSignedTransaction>} - the raw signed transaction to broadcast
    */
   async signTransaction(
     accountId: string,
     transaction: Transaction,
     params?: SignTransactionParams
-  ): Promise<SignedTransaction> {
-    const rawSignedTransaction = await this._request<RawSignedTransaction>(
-      "transaction.sign",
-      {
-        accountId,
-        transaction: serializeTransaction(transaction),
-        params: params || {},
-      }
-    );
-
-    return deserializeSignedTransaction(rawSignedTransaction);
+  ): Promise<RawSignedTransaction> {
+    return this._request<RawSignedTransaction>("transaction.sign", {
+      accountId,
+      transaction: serializeTransaction(transaction),
+      params: params || {},
+    });
   }
 
   /**
    * Broadcast a signed transaction through Ledger Live, providing an optimistic Operation given by signTransaction
    * @param {string} accountId - LL id of the account
-   * @param {SignedTransaction} signedTransaction - a signed transaction given by LL when signing
+   * @param {RawSignedTransaction} signedTransaction - a raw signed transaction returned by LL when signing
    *
    * @returns {Promise<string>} - hash of the transaction
    */
   async broadcastSignedTransaction(
     accountId: string,
-    signedTransaction: SignedTransaction
+    signedTransaction: RawSignedTransaction
   ): Promise<string> {
     return this._request("transaction.broadcast", {
       accountId,
-      signedTransaction: serializeSignedTransaction(signedTransaction),
+      signedTransaction,
     });
   }
 

--- a/src/mock/index.ts
+++ b/src/mock/index.ts
@@ -2,9 +2,10 @@
 import data from "./mocks.json";
 import type { RequestAccountParams } from "../LedgerLivePlatformSDK/params.types";
 import generateRandomTxID from "./generateRandomTxID";
-import type { Account, Currency, SignedTransaction } from "../types";
+import type { Account, Currency } from "../types";
 import { deserializeAccount } from "../serializers";
 import LedgerLivePlatformSDK from "../LedgerLivePlatformSDK";
+import { RawSignedTransaction } from "../rawTypes";
 
 const { rawAccounts, rawCurrencies } = data;
 
@@ -95,7 +96,7 @@ export default class LedgerLiveSDKMock
   async signTransaction(
     _accountId: string,
     _transaction: unknown
-  ): Promise<SignedTransaction> {
+  ): Promise<RawSignedTransaction> {
     if (!this.connected) {
       throw new Error("Ledger Live API not connected");
     }
@@ -108,7 +109,7 @@ export default class LedgerLiveSDKMock
 
   async broadcastSignedTransaction(
     _accountId: string,
-    _signedTransaction: SignedTransaction
+    _signedTransaction: RawSignedTransaction
   ): Promise<string> {
     if (!this.connected) {
       throw new Error("Ledger Live API not connected");

--- a/src/serializers.ts
+++ b/src/serializers.ts
@@ -148,6 +148,7 @@ export function deserializeTransaction(
   }
 }
 
+// FIXME: remove serializeSignedTransaction and deserializeSignedTransaction as well as related tests
 export function serializeSignedTransaction({
   operation,
   signature,

--- a/src/serializers.ts
+++ b/src/serializers.ts
@@ -41,12 +41,8 @@ import {
 } from "./families/tron/serializer";
 import FAMILIES from "./families/types";
 
-import type {
-  RawAccount,
-  RawSignedTransaction,
-  RawTransaction,
-} from "./rawTypes";
-import type { Account, SignedTransaction, Transaction } from "./types";
+import type { RawAccount, RawTransaction } from "./rawTypes";
+import type { Account, Transaction } from "./types";
 
 export function serializeAccount({
   id,
@@ -146,33 +142,4 @@ export function deserializeTransaction(
     default:
       throw new Error("Can't deserialize transaction: family not supported");
   }
-}
-
-// FIXME: remove serializeSignedTransaction and deserializeSignedTransaction as well as related tests
-export function serializeSignedTransaction({
-  operation,
-  signature,
-  expirationDate,
-  signatureRaw,
-}: SignedTransaction): RawSignedTransaction {
-  return {
-    operation,
-    signature,
-    expirationDate: expirationDate ? expirationDate.toISOString() : null,
-    signatureRaw,
-  };
-}
-
-export function deserializeSignedTransaction({
-  operation,
-  signature,
-  expirationDate,
-  signatureRaw,
-}: RawSignedTransaction): SignedTransaction {
-  return {
-    operation: operation || {},
-    signature,
-    expirationDate: expirationDate ? new Date(expirationDate) : null,
-    signatureRaw,
-  };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,17 +19,6 @@ export interface Transport {
   send(payload: unknown): Promise<void>;
 }
 
-// FIXME: Not implemented yet, to remove
-export type Operation = unknown;
-
-// FIXME: remove SignedTransaction type
-export type SignedTransaction = {
-  operation: Operation;
-  signature: string;
-  signatureRaw?: unknown;
-  expirationDate: Date | null;
-};
-
 /**
  * Metadata used to describe a secure exchange between a Ledger device
  * and a partner (for sell, swap and funding)

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,9 +19,10 @@ export interface Transport {
   send(payload: unknown): Promise<void>;
 }
 
-// FIXME: Not implemented yet
+// FIXME: Not implemented yet, to remove
 export type Operation = unknown;
 
+// FIXME: remove SignedTransaction type
 export type SignedTransaction = {
   operation: Operation;
   signature: string;

--- a/tests/unit/LedgerLivePlatformSDK/index.spec.ts
+++ b/tests/unit/LedgerLivePlatformSDK/index.spec.ts
@@ -4,7 +4,7 @@ import ChaiSpies from "chai-spies";
 import { before } from "mocha";
 import logger from "../../utils/Logger.mock";
 import WindowMock from "../../utils/Window.mock";
-import type { Account, Currency, SignedTransaction } from "../../../src/types";
+import type { Account, Currency } from "../../../src/types";
 import MessageEventMock from "../../utils/MessageEvent.mock";
 import LedgerLivePlatformSDK from "../../../src/LedgerLivePlatformSDK";
 import WindowMessageTransport from "../../../src/transports/windowMessageTransport";
@@ -153,7 +153,7 @@ describe("LedgerLivePlatformSDK/index.ts", () => {
 
         const optimisticOperationHash = "optimisticOperation.hash";
         const accountId = "accountId";
-        const signedTransaction: SignedTransaction = {
+        const signedTransaction: RawSignedTransaction = {
           operation: null,
           signature: "signature",
           expirationDate: null,
@@ -375,12 +375,7 @@ describe("LedgerLivePlatformSDK/index.ts", () => {
         }) as ChaiSpies.Spy;
 
         const res = await SDK.signTransaction(accountId, transaction);
-        expect(res).to.deep.eq({
-          operation: {},
-          expirationDate: date,
-          signature: "signature",
-          signatureRaw: undefined,
-        });
+        expect(res).to.deep.eq(rawSignedTransaction);
         expect(spy).to.be.have.been.called.with(
           `{"jsonrpc":"2.0","method":"transaction.sign","params":{"accountId":"${accountId}","transaction":${JSON.stringify(
             transaction

--- a/tests/unit/serializers.spec.ts
+++ b/tests/unit/serializers.spec.ts
@@ -2,12 +2,8 @@ import { expect } from "chai";
 import BigNumber from "bignumber.js";
 import FAMILIES from "../../src/families/types";
 import * as serializers from "../../src/serializers";
-import type { Account, SignedTransaction, Transaction } from "../../src/types";
-import type {
-  RawAccount,
-  RawSignedTransaction,
-  RawTransaction,
-} from "../../src/rawTypes";
+import type { Account, Transaction } from "../../src/types";
+import type { RawAccount, RawTransaction } from "../../src/rawTypes";
 import type {
   BitcoinTransaction,
   RawBitcoinTransaction,
@@ -1057,69 +1053,6 @@ describe("serializers.ts", () => {
     });
   });
 
-  describe("serializeSignedTransaction", () => {
-    it("should succeed to serialize a signed transaction", () => {
-      const serializedTransaction = serializers.serializeSignedTransaction({
-        operation: null,
-        signature: "signature",
-        signatureRaw: null,
-        expirationDate: date,
-      });
-      const serializedTransactionWithoutExpDate =
-        serializers.serializeSignedTransaction({
-          operation: null,
-          signature: "signature",
-          signatureRaw: null,
-          expirationDate: null,
-        });
-
-      expect(serializedTransaction).to.deep.eq({
-        operation: null,
-        signature: "signature",
-        expirationDate: date.toISOString(),
-        signatureRaw: null,
-      });
-
-      expect(serializedTransactionWithoutExpDate).to.deep.eq({
-        operation: null,
-        signature: "signature",
-        expirationDate: null,
-        signatureRaw: null,
-      });
-    });
-  });
-
-  describe("deserializeSignedTransaction", () => {
-    it("should succeed to deserialize a raw signed transaction", () => {
-      const transaction = serializers.deserializeSignedTransaction({
-        operation: null,
-        signature: "signature",
-        signatureRaw: null,
-        expirationDate: date.toISOString(),
-      });
-      const transactionWithoutExpDate =
-        serializers.deserializeSignedTransaction({
-          operation: null,
-          signature: "signature",
-          signatureRaw: null,
-          expirationDate: null,
-        });
-
-      expect(transaction).to.deep.eq({
-        operation: {},
-        signature: "signature",
-        expirationDate: date,
-        signatureRaw: null,
-      });
-      expect(transactionWithoutExpDate).to.deep.eq({
-        operation: {},
-        signature: "signature",
-        expirationDate: null,
-        signatureRaw: null,
-      });
-    });
-  });
-
   describe("Serialize -> Deserialize flow", () => {
     describe("Account", () => {
       it("should not alter account", () => {
@@ -1165,30 +1098,6 @@ describe("serializers.ts", () => {
           serializers.deserializeTransaction(parsedTransaction);
 
         expect(transaction).to.deep.eq(expectedTransaction);
-      });
-    });
-
-    describe("SignedTransaction", () => {
-      it("should not alter SignedTransaction", () => {
-        const signedTransaction: SignedTransaction = {
-          operation: {},
-          signature: "signature",
-          signatureRaw: null,
-          expirationDate: date,
-        };
-
-        const serializedSignedTransaction =
-          serializers.serializeSignedTransaction(signedTransaction);
-        const stringifiedSignedTransaction = JSON.stringify(
-          serializedSignedTransaction
-        );
-        const parsedSignedTransaction = JSON.parse(
-          stringifiedSignedTransaction
-        ) as RawSignedTransaction;
-        const expectedSignedTransaction =
-          serializers.deserializeSignedTransaction(parsedSignedTransaction);
-
-        expect(signedTransaction).to.deep.eq(expectedSignedTransaction);
       });
     });
   });


### PR DESCRIPTION
Make `signTransaction` and `broadcastSignedTransaction` use `RawSignedTransaction` instead of `SignedTransaction`.

The current implementation of `signTransaction` and `broadcastSignedTransaction` rely on the `SignedTransaction` type which includes an `operation` property of `Operation` type. Or, the `Operation` type is LL specific and mainly used for display purposes in LLD and LLM (to display an optimistic operation). Hence the use of a `serializeSignedTransaction` and a `deserializeSignedTransaction` function. But this is misleading since neither `serializeSignedTransaction` nor `deserializeSignedTransaction` knows how to serialize or deserialize an LL specific operation. Therefore, when calling `signTransaction`, we get the false impression that we will receive a deserialised object whereas the result is only partially deserialised (since the operation is not known by the SDK and therefore kept untouched).

Also, since the current `signTransaction` implementation returns a `SignedTransaction` (deserialised using `deserializeSignedTransaction` because the json-rpc call actually returns a `RawSignedTransaction`), we have to re serialize this signedTransaction argument in the `broadcastSignedTransaction` function.

Is there a reason for the SDK to return a deserialised signedTransaction since, as far as I know, the only thing that can be done with it is broadcast it (immediately or at a later time) using `broadcastSignedTransaction`. As far as I understand, transaction shouldn't (and can't?) be updated between the sign and the broadcast steps (otherwise what's the point in signing it if it can be tempered before broadcast).

[Example usage in the DAPPBrowser case](https://github.com/LedgerHQ/ledger-live-platform-apps/blob/main/src/DAPPBrowser/index.tsx#L209-L217), where the returned signedTransaction is just used as argument for the broadcast step and is not read nor updated in between.

Overall, this is pretty misleading and complex for no obvious benefit.

This is also the reason why we can't use the SDK `serializeSignedTransaction` and `deserializeSignedTransaction` functions in LLC (cf. [here](https://github.com/LedgerHQ/ledger-live-common/pull/1328/files#diff-82a648d3799536029bd623a0b2475c875265710aef01859395005556c0fcaa22R12)). 

In my opinion the SDK should be operation agnostic (i.e don't care about anything related to operations).

This proposed change is non breaking as of today since the whole operation (de)serializeation logic is already handled on LLC side (cf. [here](https://github.com/LedgerHQ/ledger-live-common/blob/24448f724d24e42af93b5de7b34dd99d434bef15/src/platform/serializers.ts#L13-L23)).

---

On the other hand, if we want to keep dealing with deserialised signedTransaction (but then again, what's the use-case?), then we should make it explicit that the operation is a raw payload and will remain untouched (serialized). We should also decouple the transaction and operations (de)serialization logic (i.e: the transaction part is handled by SDK while the operation part is handled by LLC), which is not the case as of today (cf. [LLC](https://github.com/LedgerHQ/ledger-live-common/blob/24448f724d24e42af93b5de7b34dd99d434bef15/src/platform/serializers.ts#L13-L23) where `serializePlatformSignedTransaction` is juste a call to LLC's `toSignedOperationRaw`, same thing for the deserialization part).

If we go this way, we might need to change some logic in the `signTransaction` and `broadcastTransaction` handlers on LLD / LLM side (cf. [here](https://github.com/LedgerHQ/ledger-live-desktop/blob/develop/src/renderer/components/WebPlatformPlayer/index.js#L278-L279)) regarding deserialisation 

---

TODO:

- [ ] Step 1: decide what we do
     - [ ] Do we use `RawSignedTransaction` instead of `SignedTransaction` (proposal 1)
     - [ ] Do we keep on using `SignedTransaction` but disambiguate the fact that the `operation` inside the transaction is not touched (not serialized not deserialized)
     - [ ] Do we do nothing and keep it as is (wouldn't recommend it)
- [ ] Step 2: Update the SDK accordingly (and any impacted repo depending on the selected solution)