### PR TITLE
Add missing PolkadotOperationMode to polkadot type

### DIFF
--- a/src/families/polkadot/types.ts
+++ b/src/families/polkadot/types.ts
@@ -5,16 +5,27 @@ import FAMILIES from "../types";
 import type { RawTransactionCommon } from "../../rawTypes";
 import type { TransactionCommon } from "../../types";
 
+export type PolkadotOperationMode =
+  | "send"
+  | "bond"
+  | "unbond"
+  | "rebond"
+  | "withdrawUnbonded"
+  | "setController"
+  | "nominate"
+  | "chill"
+  | "claimReward";
+
 export interface PolkadotTransaction extends TransactionCommon {
   readonly family: FAMILIES.POLKADOT;
-  mode: string;
+  mode: PolkadotOperationMode;
   fee?: BigNumber;
   era?: number;
 }
 
 export interface RawPolkadotTransaction extends RawTransactionCommon {
   readonly family: FAMILIES.POLKADOT;
-  mode: string;
+  mode: PolkadotOperationMode;
   fee?: string;
   era?: number;
 }

--- a/tests/unit/serializers.spec.ts
+++ b/tests/unit/serializers.spec.ts
@@ -327,7 +327,7 @@ describe("serializers.ts", () => {
       it("should succeed to serialize a polkadot transaction with fee and era", () => {
         const transaction: PolkadotTransaction = {
           family: FAMILIES.POLKADOT,
-          mode: "mode",
+          mode: "send",
           fee: new BigNumber(1),
           era: 4,
           amount: new BigNumber(100),
@@ -338,7 +338,7 @@ describe("serializers.ts", () => {
 
         expect(serializedTransaction).to.deep.eq({
           family: FAMILIES.POLKADOT,
-          mode: "mode",
+          mode: "send",
           fee: "1",
           era: 4,
           amount: "100",
@@ -349,7 +349,7 @@ describe("serializers.ts", () => {
       it("should succeed to serialize a polkadot transaction without fee and era", () => {
         const transaction: PolkadotTransaction = {
           family: FAMILIES.POLKADOT,
-          mode: "mode",
+          mode: "send",
           amount: new BigNumber(100),
           recipient: "recipient",
         };
@@ -358,7 +358,7 @@ describe("serializers.ts", () => {
 
         expect(serializedTransaction).to.deep.eq({
           family: FAMILIES.POLKADOT,
-          mode: "mode",
+          mode: "send",
           fee: undefined,
           era: undefined,
           amount: "100",
@@ -803,7 +803,7 @@ describe("serializers.ts", () => {
       it("should succeed to deserialize a polkadot transaction with fee and era", () => {
         const serializedTransaction: RawPolkadotTransaction = {
           family: FAMILIES.POLKADOT,
-          mode: "mode",
+          mode: "send",
           fee: "1",
           era: 4,
           amount: "100",
@@ -816,7 +816,7 @@ describe("serializers.ts", () => {
 
         expect(transaction).to.deep.eq({
           family: FAMILIES.POLKADOT,
-          mode: "mode",
+          mode: "send",
           fee: new BigNumber(1),
           era: 4,
           amount: new BigNumber(100),
@@ -827,7 +827,7 @@ describe("serializers.ts", () => {
       it("should succeed to deserialize a polkadot transaction without fee and era", () => {
         const serializedTransaction: RawPolkadotTransaction = {
           family: FAMILIES.POLKADOT,
-          mode: "mode",
+          mode: "send",
           amount: "100",
           recipient: "recipient",
         };
@@ -838,7 +838,7 @@ describe("serializers.ts", () => {
 
         expect(transaction).to.deep.eq({
           family: FAMILIES.POLKADOT,
-          mode: "mode",
+          mode: "send",
           fee: undefined,
           era: undefined,
           amount: new BigNumber(100),


### PR DESCRIPTION
Add missing PolkadotOperationMode to polkadot type [as per in LLC ](https://github.com/LedgerHQ/ledger-live-common/blob/master/src/families/polkadot/types.ts#L16-L25)

cf. [this comment](https://github.com/LedgerHQ/ledger-live-common/pull/1351/files#diff-9844eb95d410761decaebf1f5f9cac6f9be47aee97700232c858412247e207cdR11)