### PR TITLE
[LL-7299] Add tx mocks per family

### DIFF
--- a/src/families/algorand/mocks.ts
+++ b/src/families/algorand/mocks.ts
@@ -1,0 +1,31 @@
+import BigNumber from "bignumber.js";
+
+import { rawTxCommon, txCommon } from "../../mock/transactionCommon";
+import FAMILIES from "../types";
+import { AlgorandTransaction, RawAlgorandTransaction } from "./types";
+
+export const rawTx: RawAlgorandTransaction = {
+  ...rawTxCommon,
+  family: FAMILIES.ALGORAND,
+  mode: "send",
+};
+
+export const rawTxFull: Required<RawAlgorandTransaction> = {
+  ...rawTx,
+  fees: "1",
+  assetId: "[ASSET_ID]",
+  memo: "[MEMO]",
+};
+
+export const tx: AlgorandTransaction = {
+  ...txCommon,
+  family: FAMILIES.ALGORAND,
+  mode: "send",
+};
+
+export const txFull: Required<AlgorandTransaction> = {
+  ...tx,
+  fees: new BigNumber(1),
+  assetId: "[ASSET_ID]",
+  memo: "[MEMO]",
+};

--- a/src/families/bitcoin/mocks.ts
+++ b/src/families/bitcoin/mocks.ts
@@ -1,0 +1,24 @@
+import BigNumber from "bignumber.js";
+import { rawTxCommon, txCommon } from "../../mock/transactionCommon";
+import FAMILIES from "../types";
+import { BitcoinTransaction, RawBitcoinTransaction } from "./types";
+
+export const rawTx: RawBitcoinTransaction = {
+  ...rawTxCommon,
+  family: FAMILIES.BITCOIN,
+};
+
+export const rawTxFull: Required<RawBitcoinTransaction> = {
+  ...rawTx,
+  feePerByte: "10",
+};
+
+export const tx: BitcoinTransaction = {
+  ...txCommon,
+  family: FAMILIES.BITCOIN,
+};
+
+export const txFull: Required<BitcoinTransaction> = {
+  ...tx,
+  feePerByte: new BigNumber(10),
+};

--- a/src/families/cosmos/mocks.ts
+++ b/src/families/cosmos/mocks.ts
@@ -1,0 +1,30 @@
+import BigNumber from "bignumber.js";
+import { rawTxCommon, txCommon } from "../../mock/transactionCommon";
+import FAMILIES from "../types";
+import { CosmosTransaction, RawCosmosTransaction } from "./types";
+
+export const rawTx: RawCosmosTransaction = {
+  ...rawTxCommon,
+  family: FAMILIES.COSMOS,
+  mode: "send",
+};
+
+export const rawTxFull: Required<RawCosmosTransaction> = {
+  ...rawTx,
+  fees: "10",
+  gas: "100",
+  memo: "[MEMO]",
+};
+
+export const tx: CosmosTransaction = {
+  ...txCommon,
+  family: FAMILIES.COSMOS,
+  mode: "send",
+};
+
+export const txFull: Required<CosmosTransaction> = {
+  ...tx,
+  fees: new BigNumber(10),
+  gas: new BigNumber(100),
+  memo: "[MEMO]",
+};

--- a/src/families/crypto_org/mocks.ts
+++ b/src/families/crypto_org/mocks.ts
@@ -1,0 +1,27 @@
+import BigNumber from "bignumber.js";
+
+import { rawTxCommon, txCommon } from "../../mock/transactionCommon";
+import FAMILIES from "../types";
+import { CryptoOrgTransaction, RawCryptoOrgTransaction } from "./types";
+
+export const rawTx: RawCryptoOrgTransaction = {
+  ...rawTxCommon,
+  family: FAMILIES.CRYPTO_ORG,
+  mode: "send",
+};
+
+export const rawTxFull: Required<RawCryptoOrgTransaction> = {
+  ...rawTx,
+  fees: "10",
+};
+
+export const tx: CryptoOrgTransaction = {
+  ...txCommon,
+  family: FAMILIES.CRYPTO_ORG,
+  mode: "send",
+};
+
+export const txFull: Required<CryptoOrgTransaction> = {
+  ...tx,
+  fees: new BigNumber(10),
+};

--- a/src/families/ethereum/mocks.ts
+++ b/src/families/ethereum/mocks.ts
@@ -1,0 +1,30 @@
+import BigNumber from "bignumber.js";
+import { rawTxCommon, txCommon } from "../../mock/transactionCommon";
+import FAMILIES from "../types";
+import { EthereumTransaction, RawEthereumTransaction } from "./types";
+
+export const rawTx: RawEthereumTransaction = {
+  ...rawTxCommon,
+  family: FAMILIES.ETHEREUM,
+};
+
+export const rawTxFull: Required<RawEthereumTransaction> = {
+  ...rawTx,
+  nonce: 1,
+  data: "44415441",
+  gasPrice: "10",
+  gasLimit: "100",
+};
+
+export const tx: EthereumTransaction = {
+  ...txCommon,
+  family: FAMILIES.ETHEREUM,
+};
+
+export const txFull: Required<EthereumTransaction> = {
+  ...tx,
+  nonce: 1,
+  data: Buffer.from("44415441", "hex"),
+  gasPrice: new BigNumber("10"),
+  gasLimit: new BigNumber("100"),
+};

--- a/src/families/polkadot/mocks.ts
+++ b/src/families/polkadot/mocks.ts
@@ -1,0 +1,28 @@
+import BigNumber from "bignumber.js";
+import { rawTxCommon, txCommon } from "../../mock/transactionCommon";
+import FAMILIES from "../types";
+import { PolkadotTransaction, RawPolkadotTransaction } from "./types";
+
+export const rawTx: RawPolkadotTransaction = {
+  ...rawTxCommon,
+  family: FAMILIES.POLKADOT,
+  mode: "send",
+};
+
+export const rawTxFull: Required<RawPolkadotTransaction> = {
+  ...rawTx,
+  fee: "10",
+  era: 1,
+};
+
+export const tx: PolkadotTransaction = {
+  ...txCommon,
+  family: FAMILIES.POLKADOT,
+  mode: "send",
+};
+
+export const txFull: Required<PolkadotTransaction> = {
+  ...tx,
+  fee: new BigNumber("10"),
+  era: 1,
+};

--- a/src/families/ripple/mocks.ts
+++ b/src/families/ripple/mocks.ts
@@ -1,0 +1,28 @@
+import BigNumber from "bignumber.js";
+import { rawTxCommon, txCommon } from "../../mock/transactionCommon";
+import FAMILIES from "../types";
+import { RawRippleTransaction, RippleTransaction } from "./types";
+
+export const rawTx: RawRippleTransaction = {
+  ...rawTxCommon,
+  family: FAMILIES.RIPPLE,
+  tag: 1,
+};
+
+export const rawTxFull: Required<RawRippleTransaction> = {
+  ...rawTx,
+  fee: "10",
+  tag: 1,
+};
+
+export const tx: RippleTransaction = {
+  ...txCommon,
+  family: FAMILIES.RIPPLE,
+  tag: 1,
+};
+
+export const txFull: Required<RippleTransaction> = {
+  ...tx,
+  fee: new BigNumber("10"),
+  tag: 1,
+};

--- a/src/families/stellar/mocks.ts
+++ b/src/families/stellar/mocks.ts
@@ -1,0 +1,28 @@
+import BigNumber from "bignumber.js";
+import { rawTxCommon, txCommon } from "../../mock/transactionCommon";
+import FAMILIES from "../types";
+import { RawStellarTransaction, StellarTransaction } from "./types";
+
+export const rawTx: RawStellarTransaction = {
+  ...rawTxCommon,
+  family: FAMILIES.STELLAR,
+};
+
+export const rawTxFull: Required<RawStellarTransaction> = {
+  ...rawTx,
+  fees: "10",
+  memoType: "[MEMO-TYPE]",
+  memoValue: "[MEMO-VALUE]",
+};
+
+export const tx: StellarTransaction = {
+  ...txCommon,
+  family: FAMILIES.STELLAR,
+};
+
+export const txFull: Required<StellarTransaction> = {
+  ...tx,
+  fees: new BigNumber("10"),
+  memoType: "[MEMO-TYPE]",
+  memoValue: "[MEMO-VALUE]",
+};

--- a/src/families/tezos/mocks.ts
+++ b/src/families/tezos/mocks.ts
@@ -1,0 +1,30 @@
+import BigNumber from "bignumber.js";
+import { rawTxCommon, txCommon } from "../../mock/transactionCommon";
+import FAMILIES from "../types";
+import { RawTezosTransaction, TezosTransaction } from "./types";
+
+export const rawTx: RawTezosTransaction = {
+  ...rawTxCommon,
+  family: FAMILIES.TEZOS,
+  mode: "send",
+};
+
+export const rawTxFull: Required<RawTezosTransaction> = {
+  ...rawTx,
+  fees: "10",
+  mode: "send",
+  gasLimit: "100",
+};
+
+export const tx: TezosTransaction = {
+  ...txCommon,
+  family: FAMILIES.TEZOS,
+  mode: "send",
+};
+
+export const txFull: Required<TezosTransaction> = {
+  ...tx,
+  fees: new BigNumber("10"),
+  gasLimit: new BigNumber("100"),
+  mode: "send",
+};

--- a/src/families/tron/mocks.ts
+++ b/src/families/tron/mocks.ts
@@ -1,0 +1,29 @@
+import { rawTxCommon, txCommon } from "../../mock/transactionCommon";
+import FAMILIES from "../types";
+import { RawTronTransaction, TronTransaction } from "./types";
+
+export const rawTx: RawTronTransaction = {
+  ...rawTxCommon,
+  family: FAMILIES.TRON,
+  mode: "send",
+};
+
+export const rawTxFull: Required<RawTronTransaction> = {
+  ...rawTx,
+  mode: "send",
+  resource: "BANDWIDTH",
+  duration: 1,
+};
+
+export const tx: TronTransaction = {
+  ...txCommon,
+  family: FAMILIES.TRON,
+  mode: "send",
+};
+
+export const txFull: Required<TronTransaction> = {
+  ...tx,
+  mode: "send",
+  resource: "BANDWIDTH",
+  duration: 1,
+};

--- a/src/mock/transactionCommon.ts
+++ b/src/mock/transactionCommon.ts
@@ -1,0 +1,12 @@
+import BigNumber from "bignumber.js";
+import { RawTransactionCommon, TransactionCommon } from "..";
+
+export const rawTxCommon: Omit<RawTransactionCommon, "family"> = {
+  amount: "1",
+  recipient: "[RECIPIENT_ADDRESS]",
+};
+
+export const txCommon: Omit<TransactionCommon, "family"> = {
+  amount: new BigNumber(1),
+  recipient: "[RECIPIENT_ADDRESS]",
+};


### PR DESCRIPTION
Add basic transaction and rawTransaction mocks for each coin family.

These basic mocks are used by the new debug app for payload placeholder.

They could also be used for testing purposes