### PR TITLE
Update payload and signature type to Buffer

### DIFF
--- a/src/LedgerLivePlatformSDK/index.ts
+++ b/src/LedgerLivePlatformSDK/index.ts
@@ -189,9 +189,9 @@ export default class LedgerLivePlatformSDK {
       provider,
       fromAccountId,
       toAccountId,
-      transaction,
-      binaryPayload,
-      signature,
+      transaction: serializeTransaction(transaction),
+      binaryPayload: binaryPayload.toString("hex"),
+      signature: signature.toString("hex"),
       feesStrategy,
       exchangeType,
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,15 +42,20 @@ export interface Transport {
 }
 /**
  * Metadata used to describe a secure exchange between a Ledger device
- * and a partner (for sell, swap and funding). This information is displayed
- * as a hex string of the protobuf containing all the data from the exchange
+ * and a partner (for sell, swap and funding)
  * @ref: https://github.com/LedgerHQ/app-exchange/blob/master/src/proto/protocol.proto
  */
-export type ExchangePayload = string;
+export type ExchangePayload = Buffer;
 
+/**
+ * The ECDSA signature of the [[ExchangePayload | payload]]
+ */
+export type EcdsaSignature = Buffer;
+
+/**
+ * A transaction ID used to complete the exchange process
+ */
 export type ExchangeDeviceTxId = string;
-
-export type EcdsaSignature = string;
 
 /**
  * Abstract level of fees for a transaction

--- a/tests/unit/LedgerLivePlatformSDK/index.spec.ts
+++ b/tests/unit/LedgerLivePlatformSDK/index.spec.ts
@@ -474,8 +474,8 @@ describe("LedgerLivePlatformSDK/index.ts", () => {
           fromAccountId: "FROM_ACCOUNT_ID",
           toAccountId: recipientAccountId,
           transaction: tx,
-          binaryPayload: "payload",
-          signature: "signature",
+          binaryPayload: Buffer.from("payload", "utf-8"),
+          signature: Buffer.from("signature", "utf-8"),
           feesStrategy: FeesLevel.Fast,
           exchangeType,
         };
@@ -510,7 +510,12 @@ describe("LedgerLivePlatformSDK/index.ts", () => {
 
         expect(spy).to.be.have.been.called.with(
           `{"jsonrpc":"2.0","method":"exchange.complete","params":${JSON.stringify(
-            completeExchangeParams
+            {
+              ...completeExchangeParams,
+              binaryPayload:
+                completeExchangeParams.binaryPayload.toString("hex"),
+              signature: completeExchangeParams.signature.toString("hex"),
+            }
           )},"id":1}`
         );
       });
@@ -532,8 +537,8 @@ describe("LedgerLivePlatformSDK/index.ts", () => {
           provider: "PROVIDER",
           fromAccountId: "FROM_ACCOUNT_ID",
           transaction: tx,
-          binaryPayload: "payload",
-          signature: "signature",
+          binaryPayload: Buffer.from("payload", "utf-8"),
+          signature: Buffer.from("signature", "utf-8"),
           feesStrategy: FeesLevel.Fast,
           exchangeType,
         };


### PR DESCRIPTION
`completeExchange` now uses `Buffer` instead of `string` for `binaryPayload` and `signature` arguments so that function user does not have to care about buffer encoding