### PR TITLE
Feat/live 2472 sign message

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@
 
 # Contributing
 
-Please read our [contribution guidelines](./CONTRIBUTING.md) before getting
-started.
+Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
 
 **You need to have a recent [Node.js](https://nodejs.org/) and
 [Yarn 1 (Classic)](https://classic.yarnpkg.com/lang/en/) installed.**
@@ -115,7 +114,7 @@ The documentation will be generated in a `docs/markdown` or `docs/html` folder d
 
 This generated package is hosted on NPM [here](https://www.npmjs.com/package/@ledgerhq/live-app-sdk).
 
-⚠️ Publishing can only be performed by memebers of the [_ledgerhq_ organization](https://www.npmjs.com/org/ledgerhq) having the necessary rights to push to `main` branch ⚠️
+⚠️ Publishing can only be performed by members of the [_ledgerhq_ organization](https://www.npmjs.com/org/ledgerhq) having the necessary rights to push to `main` branch ⚠️
 
 In order to publish a new version of this package, please refer to the following steps:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/live-app-sdk",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "repository": "git@github.com:LedgerHQ/ledger-live-platform-sdk.git",
   "license": "Apache-2.0",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "json-rpc-2.0": "^1.1.0"
   },
   "devDependencies": {
-    "@types/bignumber.js": "^5.0.0",
     "@types/chai": "^4.3.1",
     "@types/chai-spies": "^1.0.3",
     "@types/mocha": "^9.1.0",

--- a/src/LedgerLivePlatformSDK/index.ts
+++ b/src/LedgerLivePlatformSDK/index.ts
@@ -229,8 +229,11 @@ export default class LedgerLivePlatformSDK {
    *
    * @returns Message signed
    */
-  async signMessage(accountId: string, message: string): Promise<string> {
-    return this._request("message.sign", { accountId, message });
+  async signMessage(accountId: string, message: Buffer): Promise<string> {
+    return this._request("message.sign", {
+      accountId,
+      message: message.toString("hex"),
+    });
   }
 
   /**

--- a/src/LedgerLivePlatformSDK/index.ts
+++ b/src/LedgerLivePlatformSDK/index.ts
@@ -223,6 +223,17 @@ export default class LedgerLivePlatformSDK {
   }
 
   /**
+   * Let the user sign the provided message through Ledger Live
+   * @param accountId - Ledger Live id of the account (Ethereum only)
+   * @param message - Message the user should sign
+   *
+   * @returns Message signed
+   */
+  async signMessage(accountId: string, message: string): Promise<string> {
+    return this._request("message.sign", { accountId, message });
+  }
+
+  /**
    * Broadcast a previously signed transaction through Ledger Live
    * @param accountId - Ledger Live id of the account
    * @param signedTransaction - A [[RawSignedTransaction]] returned by Ledger Live when signing with [[signTransaction]]

--- a/src/mock/index.ts
+++ b/src/mock/index.ts
@@ -105,7 +105,8 @@ export default class LedgerLiveSDKMock
     });
   }
 
-  async signMessage(_accountId: string, _message: string): Promise<string> {
+  // eslint-disable-next-line class-methods-use-this
+  async signMessage(_accountId: string, _message: Buffer): Promise<string> {
     return Promise.resolve("message signed!");
   }
 

--- a/src/mock/index.ts
+++ b/src/mock/index.ts
@@ -105,6 +105,10 @@ export default class LedgerLiveSDKMock
     });
   }
 
+  async signMessage(_accountId: string, _message: string): Promise<string> {
+    return Promise.resolve("message signed!");
+  }
+
   async broadcastSignedTransaction(
     _accountId: string,
     _signedTransaction: RawSignedTransaction

--- a/tests/unit/LedgerLivePlatformSDK/index.spec.ts
+++ b/tests/unit/LedgerLivePlatformSDK/index.spec.ts
@@ -370,7 +370,7 @@ describe("LedgerLivePlatformSDK/index.ts", () => {
         SDK.connect();
 
         const accountId = "accountId";
-        const message = "Test message";
+        const message = Buffer.from("Test message");
 
         const signedMessage = "Message signed";
 
@@ -378,9 +378,10 @@ describe("LedgerLivePlatformSDK/index.ts", () => {
 
         const res = await SDK.signMessage(accountId, message);
 
+        const expectedMessage = message.toString("hex");
         expect(res).to.deep.eq(signedMessage);
         expect(spy).to.have.been.called.with(
-          `{"jsonrpc":"2.0","method":"message.sign","params":{"accountId":"${accountId}","message":"${message}"},"id":1}`
+          `{"jsonrpc":"2.0","method":"message.sign","params":{"accountId":"${accountId}","message":"${expectedMessage}"},"id":1}`
         );
       });
     });


### PR DESCRIPTION
Add new method `signMessage` to allow EIP-191 sign capacity.

This method could be EIP-712 compatible by adding a custom type to the `signMessage` method like this:
```ts
  signMessage(accountId: string, message: Buffer | TypedMessage)
```

Depends on:
- https://github.com/LedgerHQ/ledger-live/pull/317

Relates to:
- https://github.com/LedgerHQ/eth-dapp-browser/pull/9
- https://github.com/LedgerHQ/platform-app-debug/pull/3


Do not merge until required PRs are merged (and actually deployed) ⬆️ 