### PR TITLE
[DOC][LIVE-779] add GitHub action to generate doc

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,14 +5,14 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{github.event.pull_request.head.repo.full_name}}
       - uses: actions/setup-node@main
         with:
           node-version: 14.x
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: cache
         with:
           path: "**/node_modules"
@@ -24,14 +24,14 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{github.event.pull_request.head.repo.full_name}}
       - uses: actions/setup-node@main
         with:
           node-version: 14.x
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
@@ -43,14 +43,14 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{github.event.pull_request.head.repo.full_name}}
       - uses: actions/setup-node@main
         with:
           node-version: 14.x
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
@@ -64,14 +64,14 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{github.event.pull_request.head.repo.full_name}}
       - uses: actions/setup-node@main
         with:
           node-version: 14.x
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,6 +60,25 @@ jobs:
         run: npx codecov
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  test-doc:
+    name: "Test Documentation"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+      - uses: actions/setup-node@main
+        with:
+          node-version: 14.x
+      - uses: actions/cache@v3
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+      - name: run doc
+        run: yarn doc
+      - name: check if diff
+        run: git diff --exit-code || exit 1
   build:
     needs: setup
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-
-   
 <p align="center">
  <img src="https://user-images.githubusercontent.com/9203826/154288895-670f5c23-81a1-4307-a080-1af83f7f8356.svg" align="center" alt="Ledger" />
  <h2 align="center">Live App SDK</h2>
@@ -39,9 +37,6 @@
     <a href="https://github.com/LedgerHQ/live-app-sdk/issues/new/choose">Request Feature</a>
   </p>
 </p>
-
-
-
 
 # Contributing
 
@@ -127,8 +122,6 @@ In order to publish a new version of this package, please refer to the following
 
 [We are hiring, join us! 🚀](https://www.ledger.com/join-us)
 
-
 ### See also:
 
-- [Ledger Live Desktop](https://github.com/ledgerhq/ledger-live-desktop)
-- [Ledger Live Mobile](https://github.com/ledgerhq/ledger-live-mobile)
+- [Ledger Live](https://github.com/LedgerHQ/ledger-live)

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,6 +1,5 @@
 @ledgerhq/live-app-sdk / [Exports](modules.md)
 
-   
 <p align="center">
  <img src="https://user-images.githubusercontent.com/9203826/154288895-670f5c23-81a1-4307-a080-1af83f7f8356.svg" align="center" alt="Ledger" />
  <h2 align="center">Live App SDK</h2>
@@ -127,5 +126,4 @@ In order to publish a new version of this package, please refer to the following
 
 ### See also:
 
-- [Ledger Live Desktop](https://github.com/ledgerhq/ledger-live-desktop)
-- [Ledger Live Mobile](https://github.com/ledgerhq/ledger-live-mobile)
+- [Ledger Live](https://github.com/LedgerHQ/ledger-live)

--- a/docs/reference/classes/LedgerLivePlatformSDK.md
+++ b/docs/reference/classes/LedgerLivePlatformSDK.md
@@ -37,7 +37,7 @@
 
 #### Defined in
 
-[LedgerLivePlatformSDK/index.ts:54](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/LedgerLivePlatformSDK/index.ts#L54)
+[LedgerLivePlatformSDK/index.ts:54](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L54)
 
 ## Methods
 
@@ -62,7 +62,7 @@ The hash of the transaction
 
 #### Defined in
 
-[LedgerLivePlatformSDK/index.ts:246](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/LedgerLivePlatformSDK/index.ts#L246)
+[LedgerLivePlatformSDK/index.ts:246](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L246)
 
 ___
 
@@ -97,7 +97,7 @@ If the exchange is validated, the transaction is then signed and broadcasted to 
 
 #### Defined in
 
-[LedgerLivePlatformSDK/index.ts:165](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/LedgerLivePlatformSDK/index.ts#L165)
+[LedgerLivePlatformSDK/index.ts:165](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L165)
 
 ___
 
@@ -116,7 +116,7 @@ Establish the connection with Ledger Live through the [[transport]] instance pro
 
 #### Defined in
 
-[LedgerLivePlatformSDK/index.ts:90](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/LedgerLivePlatformSDK/index.ts#L90)
+[LedgerLivePlatformSDK/index.ts:90](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L90)
 
 ___
 
@@ -132,7 +132,7 @@ Disconnect the SDK.
 
 #### Defined in
 
-[LedgerLivePlatformSDK/index.ts:106](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/LedgerLivePlatformSDK/index.ts#L106)
+[LedgerLivePlatformSDK/index.ts:106](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L106)
 
 ___
 
@@ -157,7 +157,7 @@ The list of accounts added by the current user on Ledger Live
 
 #### Defined in
 
-[LedgerLivePlatformSDK/index.ts:261](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/LedgerLivePlatformSDK/index.ts#L261)
+[LedgerLivePlatformSDK/index.ts:261](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L261)
 
 ___
 
@@ -185,7 +185,7 @@ The list of corresponding cryptocurrencies
 
 #### Defined in
 
-[LedgerLivePlatformSDK/index.ts:336](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/LedgerLivePlatformSDK/index.ts#L336)
+[LedgerLivePlatformSDK/index.ts:336](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L336)
 
 ___
 
@@ -209,7 +209,7 @@ The verified address or an error message if the verification doesn't succeed
 
 #### Defined in
 
-[LedgerLivePlatformSDK/index.ts:312](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/LedgerLivePlatformSDK/index.ts#L312)
+[LedgerLivePlatformSDK/index.ts:312](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L312)
 
 ___
 
@@ -236,7 +236,7 @@ The account selected by the user
 
 #### Defined in
 
-[LedgerLivePlatformSDK/index.ts:281](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/LedgerLivePlatformSDK/index.ts#L281)
+[LedgerLivePlatformSDK/index.ts:281](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L281)
 
 ___
 
@@ -261,7 +261,7 @@ Message signed
 
 #### Defined in
 
-[LedgerLivePlatformSDK/index.ts:232](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/LedgerLivePlatformSDK/index.ts#L232)
+[LedgerLivePlatformSDK/index.ts:232](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L232)
 
 ___
 
@@ -288,7 +288,7 @@ The raw signed transaction to broadcast
 
 #### Defined in
 
-[LedgerLivePlatformSDK/index.ts:208](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/LedgerLivePlatformSDK/index.ts#L208)
+[LedgerLivePlatformSDK/index.ts:208](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L208)
 
 ___
 
@@ -314,4 +314,4 @@ Start the exchange process by generating a nonce on Ledger device
 
 #### Defined in
 
-[LedgerLivePlatformSDK/index.ts:141](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/LedgerLivePlatformSDK/index.ts#L141)
+[LedgerLivePlatformSDK/index.ts:141](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L141)

--- a/docs/reference/classes/Mock.md
+++ b/docs/reference/classes/Mock.md
@@ -43,7 +43,7 @@
 
 #### Defined in
 
-[mock/index.ts:34](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/mock/index.ts#L34)
+[mock/index.ts:34](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L34)
 
 ## Methods
 
@@ -68,7 +68,7 @@ MockOf.broadcastSignedTransaction
 
 #### Defined in
 
-[mock/index.ts:113](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/mock/index.ts#L113)
+[mock/index.ts:113](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L113)
 
 ___
 
@@ -86,7 +86,7 @@ MockOf.connect
 
 #### Defined in
 
-[mock/index.ts:36](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/mock/index.ts#L36)
+[mock/index.ts:36](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L36)
 
 ___
 
@@ -104,7 +104,7 @@ MockOf.disconnect
 
 #### Defined in
 
-[mock/index.ts:40](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/mock/index.ts#L40)
+[mock/index.ts:40](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L40)
 
 ___
 
@@ -124,7 +124,7 @@ ___
 
 #### Defined in
 
-[mock/index.ts:65](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/mock/index.ts#L65)
+[mock/index.ts:65](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L65)
 
 ___
 
@@ -142,7 +142,7 @@ MockOf.listAccounts
 
 #### Defined in
 
-[mock/index.ts:58](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/mock/index.ts#L58)
+[mock/index.ts:58](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L58)
 
 ___
 
@@ -160,7 +160,7 @@ MockOf.listCurrencies
 
 #### Defined in
 
-[mock/index.ts:50](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/mock/index.ts#L50)
+[mock/index.ts:50](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L50)
 
 ___
 
@@ -184,7 +184,7 @@ MockOf.receive
 
 #### Defined in
 
-[mock/index.ts:79](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/mock/index.ts#L79)
+[mock/index.ts:79](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L79)
 
 ___
 
@@ -204,7 +204,7 @@ MockOf.requestAccount
 
 #### Defined in
 
-[mock/index.ts:46](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/mock/index.ts#L46)
+[mock/index.ts:46](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L46)
 
 ___
 
@@ -229,7 +229,7 @@ MockOf.signMessage
 
 #### Defined in
 
-[mock/index.ts:109](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/mock/index.ts#L109)
+[mock/index.ts:109](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L109)
 
 ___
 
@@ -254,4 +254,4 @@ MockOf.signTransaction
 
 #### Defined in
 
-[mock/index.ts:94](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/mock/index.ts#L94)
+[mock/index.ts:94](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L94)

--- a/docs/reference/classes/WindowMessageTransport.md
+++ b/docs/reference/classes/WindowMessageTransport.md
@@ -44,7 +44,7 @@
 
 #### Defined in
 
-[transports/windowMessageTransport.ts:14](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/transports/windowMessageTransport.ts#L14)
+[transports/windowMessageTransport.ts:14](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/transports/windowMessageTransport.ts#L14)
 
 ## Properties
 
@@ -54,7 +54,7 @@
 
 #### Defined in
 
-[transports/windowMessageTransport.ts:12](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/transports/windowMessageTransport.ts#L12)
+[transports/windowMessageTransport.ts:12](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/transports/windowMessageTransport.ts#L12)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[transports/windowMessageTransport.ts:10](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/transports/windowMessageTransport.ts#L10)
+[transports/windowMessageTransport.ts:10](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/transports/windowMessageTransport.ts#L10)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[transports/windowMessageTransport.ts:8](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/transports/windowMessageTransport.ts#L8)
+[transports/windowMessageTransport.ts:8](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/transports/windowMessageTransport.ts#L8)
 
 ## Accessors
 
@@ -94,7 +94,7 @@ A function to handle new messages coming from the Ledger Live platform
 
 #### Defined in
 
-[transports/windowMessageTransport.ts:79](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/transports/windowMessageTransport.ts#L79)
+[transports/windowMessageTransport.ts:79](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/transports/windowMessageTransport.ts#L79)
 
 • `set` **onMessage**(`handler`): `void`
 
@@ -116,7 +116,7 @@ A function to handle new messages coming from the Ledger Live platform
 
 #### Defined in
 
-[transports/windowMessageTransport.ts:75](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/transports/windowMessageTransport.ts#L75)
+[transports/windowMessageTransport.ts:75](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/transports/windowMessageTransport.ts#L75)
 
 ## Methods
 
@@ -136,7 +136,7 @@ A function to handle new messages coming from the Ledger Live platform
 
 #### Defined in
 
-[transports/windowMessageTransport.ts:41](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/transports/windowMessageTransport.ts#L41)
+[transports/windowMessageTransport.ts:41](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/transports/windowMessageTransport.ts#L41)
 
 ___
 
@@ -156,7 +156,7 @@ Connect the transport instance
 
 #### Defined in
 
-[transports/windowMessageTransport.ts:19](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/transports/windowMessageTransport.ts#L19)
+[transports/windowMessageTransport.ts:19](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/transports/windowMessageTransport.ts#L19)
 
 ___
 
@@ -176,7 +176,7 @@ Disconnect the transport instance
 
 #### Defined in
 
-[transports/windowMessageTransport.ts:30](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/transports/windowMessageTransport.ts#L30)
+[transports/windowMessageTransport.ts:30](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/transports/windowMessageTransport.ts#L30)
 
 ___
 
@@ -202,4 +202,4 @@ A function to send new messages to the Ledger Live platform
 
 #### Defined in
 
-[transports/windowMessageTransport.ts:83](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/transports/windowMessageTransport.ts#L83)
+[transports/windowMessageTransport.ts:83](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/transports/windowMessageTransport.ts#L83)

--- a/docs/reference/enums/CurrencyType.md
+++ b/docs/reference/enums/CurrencyType.md
@@ -19,7 +19,7 @@ Currency types
 
 #### Defined in
 
-[types.ts:73](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L73)
+[types.ts:73](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L73)
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 #### Defined in
 
-[types.ts:74](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L74)
+[types.ts:74](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L74)

--- a/docs/reference/enums/DeviceModel.md
+++ b/docs/reference/enums/DeviceModel.md
@@ -20,7 +20,7 @@ Represents the Ledger Blue hardware device
 
 #### Defined in
 
-[types.ts:120](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L120)
+[types.ts:120](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L120)
 
 ___
 
@@ -32,7 +32,7 @@ Represents the Ledger Nano S hardware device
 
 #### Defined in
 
-[types.ts:124](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L124)
+[types.ts:124](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L124)
 
 ___
 
@@ -44,4 +44,4 @@ Represents the Ledger Nano X hardware device
 
 #### Defined in
 
-[types.ts:128](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L128)
+[types.ts:128](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L128)

--- a/docs/reference/enums/ExchangeType.md
+++ b/docs/reference/enums/ExchangeType.md
@@ -20,7 +20,7 @@ Enum describing the different types of exchanges.
 
 #### Defined in
 
-[types.ts:151](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L151)
+[types.ts:151](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L151)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[types.ts:150](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L150)
+[types.ts:150](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L150)
 
 ___
 
@@ -40,4 +40,4 @@ ___
 
 #### Defined in
 
-[types.ts:149](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L149)
+[types.ts:149](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L149)

--- a/docs/reference/enums/FAMILIES.md
+++ b/docs/reference/enums/FAMILIES.md
@@ -27,7 +27,7 @@ Supported coin families
 
 #### Defined in
 
-[families/types.ts:15](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/types.ts#L15)
+[families/types.ts:15](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/types.ts#L15)
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 #### Defined in
 
-[families/types.ts:13](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/types.ts#L13)
+[families/types.ts:13](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/types.ts#L13)
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 #### Defined in
 
-[families/types.ts:18](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/types.ts#L18)
+[families/types.ts:18](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/types.ts#L18)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[families/types.ts:16](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/types.ts#L16)
+[families/types.ts:16](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/types.ts#L16)
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 #### Defined in
 
-[families/types.ts:14](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/types.ts#L14)
+[families/types.ts:14](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/types.ts#L14)
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 #### Defined in
 
-[families/types.ts:20](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/types.ts#L20)
+[families/types.ts:20](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/types.ts#L20)
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 #### Defined in
 
-[families/types.ts:17](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/types.ts#L17)
+[families/types.ts:17](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/types.ts#L17)
 
 ___
 
@@ -97,7 +97,7 @@ ___
 
 #### Defined in
 
-[families/types.ts:21](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/types.ts#L21)
+[families/types.ts:21](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/types.ts#L21)
 
 ___
 
@@ -107,7 +107,7 @@ ___
 
 #### Defined in
 
-[families/types.ts:19](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/types.ts#L19)
+[families/types.ts:19](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/types.ts#L19)
 
 ___
 
@@ -117,4 +117,4 @@ ___
 
 #### Defined in
 
-[families/types.ts:22](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/types.ts#L22)
+[families/types.ts:22](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/types.ts#L22)

--- a/docs/reference/enums/FeesLevel.md
+++ b/docs/reference/enums/FeesLevel.md
@@ -20,7 +20,7 @@ Abstract level of fees for a transaction
 
 #### Defined in
 
-[types.ts:66](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L66)
+[types.ts:66](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L66)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[types.ts:65](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L65)
+[types.ts:65](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L65)
 
 ___
 
@@ -40,4 +40,4 @@ ___
 
 #### Defined in
 
-[types.ts:64](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L64)
+[types.ts:64](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L64)

--- a/docs/reference/enums/TokenStandard.md
+++ b/docs/reference/enums/TokenStandard.md
@@ -18,4 +18,4 @@ Token standards
 
 #### Defined in
 
-[types.ts:81](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L81)
+[types.ts:81](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L81)

--- a/docs/reference/interfaces/AlgorandTransaction.md
+++ b/docs/reference/interfaces/AlgorandTransaction.md
@@ -35,7 +35,7 @@ For example in BTC, a tx with an 'amount' field of 1 will correspond to a tx cor
 
 #### Defined in
 
-[types.ts:92](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L92)
+[types.ts:92](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L92)
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 #### Defined in
 
-[families/algorand/types.ts:14](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/algorand/types.ts#L14)
+[families/algorand/types.ts:14](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/algorand/types.ts#L14)
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 #### Defined in
 
-[families/algorand/types.ts:11](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/algorand/types.ts#L11)
+[families/algorand/types.ts:11](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/algorand/types.ts#L11)
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 #### Defined in
 
-[families/algorand/types.ts:13](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/algorand/types.ts#L13)
+[families/algorand/types.ts:13](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/algorand/types.ts#L13)
 
 ___
 
@@ -75,7 +75,7 @@ ___
 
 #### Defined in
 
-[families/algorand/types.ts:15](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/algorand/types.ts#L15)
+[families/algorand/types.ts:15](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/algorand/types.ts#L15)
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 #### Defined in
 
-[families/algorand/types.ts:12](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/algorand/types.ts#L12)
+[families/algorand/types.ts:12](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/algorand/types.ts#L12)
 
 ___
 
@@ -101,4 +101,4 @@ The address of the transaction's recipient
 
 #### Defined in
 
-[types.ts:96](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L96)
+[types.ts:96](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L96)

--- a/docs/reference/interfaces/BitcoinTransaction.md
+++ b/docs/reference/interfaces/BitcoinTransaction.md
@@ -32,7 +32,7 @@ For example in BTC, a tx with an 'amount' field of 1 will correspond to a tx cor
 
 #### Defined in
 
-[types.ts:92](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L92)
+[types.ts:92](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L92)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[families/bitcoin/types.ts:9](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/bitcoin/types.ts#L9)
+[families/bitcoin/types.ts:9](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/bitcoin/types.ts#L9)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[families/bitcoin/types.ts:10](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/bitcoin/types.ts#L10)
+[families/bitcoin/types.ts:10](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/bitcoin/types.ts#L10)
 
 ___
 
@@ -68,4 +68,4 @@ The address of the transaction's recipient
 
 #### Defined in
 
-[types.ts:96](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L96)
+[types.ts:96](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L96)

--- a/docs/reference/interfaces/CosmosTransaction.md
+++ b/docs/reference/interfaces/CosmosTransaction.md
@@ -35,7 +35,7 @@ For example in BTC, a tx with an 'amount' field of 1 will correspond to a tx cor
 
 #### Defined in
 
-[types.ts:92](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L92)
+[types.ts:92](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L92)
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 #### Defined in
 
-[families/cosmos/types.ts:17](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/cosmos/types.ts#L17)
+[families/cosmos/types.ts:17](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/cosmos/types.ts#L17)
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 #### Defined in
 
-[families/cosmos/types.ts:19](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/cosmos/types.ts#L19)
+[families/cosmos/types.ts:19](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/cosmos/types.ts#L19)
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 #### Defined in
 
-[families/cosmos/types.ts:20](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/cosmos/types.ts#L20)
+[families/cosmos/types.ts:20](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/cosmos/types.ts#L20)
 
 ___
 
@@ -75,7 +75,7 @@ ___
 
 #### Defined in
 
-[families/cosmos/types.ts:21](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/cosmos/types.ts#L21)
+[families/cosmos/types.ts:21](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/cosmos/types.ts#L21)
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 #### Defined in
 
-[families/cosmos/types.ts:18](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/cosmos/types.ts#L18)
+[families/cosmos/types.ts:18](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/cosmos/types.ts#L18)
 
 ___
 
@@ -101,4 +101,4 @@ The address of the transaction's recipient
 
 #### Defined in
 
-[types.ts:96](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L96)
+[types.ts:96](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L96)

--- a/docs/reference/interfaces/CryptoOrgTransaction.md
+++ b/docs/reference/interfaces/CryptoOrgTransaction.md
@@ -33,7 +33,7 @@ For example in BTC, a tx with an 'amount' field of 1 will correspond to a tx cor
 
 #### Defined in
 
-[types.ts:92](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L92)
+[types.ts:92](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L92)
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 #### Defined in
 
-[families/crypto_org/types.ts:9](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/crypto_org/types.ts#L9)
+[families/crypto_org/types.ts:9](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/crypto_org/types.ts#L9)
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 #### Defined in
 
-[families/crypto_org/types.ts:11](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/crypto_org/types.ts#L11)
+[families/crypto_org/types.ts:11](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/crypto_org/types.ts#L11)
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 #### Defined in
 
-[families/crypto_org/types.ts:10](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/crypto_org/types.ts#L10)
+[families/crypto_org/types.ts:10](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/crypto_org/types.ts#L10)
 
 ___
 
@@ -79,4 +79,4 @@ The address of the transaction's recipient
 
 #### Defined in
 
-[types.ts:96](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L96)
+[types.ts:96](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L96)

--- a/docs/reference/interfaces/EthereumTransaction.md
+++ b/docs/reference/interfaces/EthereumTransaction.md
@@ -35,7 +35,7 @@ For example in BTC, a tx with an 'amount' field of 1 will correspond to a tx cor
 
 #### Defined in
 
-[types.ts:92](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L92)
+[types.ts:92](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L92)
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 #### Defined in
 
-[families/ethereum/types.ts:11](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/ethereum/types.ts#L11)
+[families/ethereum/types.ts:11](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/ethereum/types.ts#L11)
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 #### Defined in
 
-[families/ethereum/types.ts:9](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/ethereum/types.ts#L9)
+[families/ethereum/types.ts:9](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/ethereum/types.ts#L9)
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 #### Defined in
 
-[families/ethereum/types.ts:13](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/ethereum/types.ts#L13)
+[families/ethereum/types.ts:13](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/ethereum/types.ts#L13)
 
 ___
 
@@ -75,7 +75,7 @@ ___
 
 #### Defined in
 
-[families/ethereum/types.ts:12](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/ethereum/types.ts#L12)
+[families/ethereum/types.ts:12](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/ethereum/types.ts#L12)
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 #### Defined in
 
-[families/ethereum/types.ts:10](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/ethereum/types.ts#L10)
+[families/ethereum/types.ts:10](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/ethereum/types.ts#L10)
 
 ___
 
@@ -101,4 +101,4 @@ The address of the transaction's recipient
 
 #### Defined in
 
-[types.ts:96](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L96)
+[types.ts:96](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L96)

--- a/docs/reference/interfaces/PolkadotTransaction.md
+++ b/docs/reference/interfaces/PolkadotTransaction.md
@@ -34,7 +34,7 @@ For example in BTC, a tx with an 'amount' field of 1 will correspond to a tx cor
 
 #### Defined in
 
-[types.ts:92](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L92)
+[types.ts:92](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L92)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[families/polkadot/types.ts:23](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/polkadot/types.ts#L23)
+[families/polkadot/types.ts:23](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/polkadot/types.ts#L23)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[families/polkadot/types.ts:20](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/polkadot/types.ts#L20)
+[families/polkadot/types.ts:20](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/polkadot/types.ts#L20)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[families/polkadot/types.ts:22](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/polkadot/types.ts#L22)
+[families/polkadot/types.ts:22](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/polkadot/types.ts#L22)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[families/polkadot/types.ts:21](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/polkadot/types.ts#L21)
+[families/polkadot/types.ts:21](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/polkadot/types.ts#L21)
 
 ___
 
@@ -90,4 +90,4 @@ The address of the transaction's recipient
 
 #### Defined in
 
-[types.ts:96](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L96)
+[types.ts:96](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L96)

--- a/docs/reference/interfaces/RawAlgorandTransaction.md
+++ b/docs/reference/interfaces/RawAlgorandTransaction.md
@@ -32,7 +32,7 @@
 
 #### Defined in
 
-[rawTypes.ts:35](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/rawTypes.ts#L35)
+[rawTypes.ts:35](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/rawTypes.ts#L35)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[families/algorand/types.ts:22](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/algorand/types.ts#L22)
+[families/algorand/types.ts:22](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/algorand/types.ts#L22)
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-[families/algorand/types.ts:19](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/algorand/types.ts#L19)
+[families/algorand/types.ts:19](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/algorand/types.ts#L19)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[families/algorand/types.ts:21](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/algorand/types.ts#L21)
+[families/algorand/types.ts:21](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/algorand/types.ts#L21)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[families/algorand/types.ts:23](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/algorand/types.ts#L23)
+[families/algorand/types.ts:23](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/algorand/types.ts#L23)
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[families/algorand/types.ts:20](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/algorand/types.ts#L20)
+[families/algorand/types.ts:20](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/algorand/types.ts#L20)
 
 ___
 
@@ -100,4 +100,4 @@ ___
 
 #### Defined in
 
-[rawTypes.ts:36](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/rawTypes.ts#L36)
+[rawTypes.ts:36](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/rawTypes.ts#L36)

--- a/docs/reference/interfaces/RawBitcoinTransaction.md
+++ b/docs/reference/interfaces/RawBitcoinTransaction.md
@@ -29,7 +29,7 @@
 
 #### Defined in
 
-[rawTypes.ts:35](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/rawTypes.ts#L35)
+[rawTypes.ts:35](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/rawTypes.ts#L35)
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 #### Defined in
 
-[families/bitcoin/types.ts:14](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/bitcoin/types.ts#L14)
+[families/bitcoin/types.ts:14](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/bitcoin/types.ts#L14)
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 #### Defined in
 
-[families/bitcoin/types.ts:15](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/bitcoin/types.ts#L15)
+[families/bitcoin/types.ts:15](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/bitcoin/types.ts#L15)
 
 ___
 
@@ -67,4 +67,4 @@ ___
 
 #### Defined in
 
-[rawTypes.ts:36](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/rawTypes.ts#L36)
+[rawTypes.ts:36](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/rawTypes.ts#L36)

--- a/docs/reference/interfaces/RawCosmosTransaction.md
+++ b/docs/reference/interfaces/RawCosmosTransaction.md
@@ -32,7 +32,7 @@
 
 #### Defined in
 
-[rawTypes.ts:35](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/rawTypes.ts#L35)
+[rawTypes.ts:35](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/rawTypes.ts#L35)
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 #### Defined in
 
-[families/cosmos/types.ts:25](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/cosmos/types.ts#L25)
+[families/cosmos/types.ts:25](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/cosmos/types.ts#L25)
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-[families/cosmos/types.ts:27](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/cosmos/types.ts#L27)
+[families/cosmos/types.ts:27](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/cosmos/types.ts#L27)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[families/cosmos/types.ts:28](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/cosmos/types.ts#L28)
+[families/cosmos/types.ts:28](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/cosmos/types.ts#L28)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[families/cosmos/types.ts:29](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/cosmos/types.ts#L29)
+[families/cosmos/types.ts:29](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/cosmos/types.ts#L29)
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[families/cosmos/types.ts:26](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/cosmos/types.ts#L26)
+[families/cosmos/types.ts:26](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/cosmos/types.ts#L26)
 
 ___
 
@@ -100,4 +100,4 @@ ___
 
 #### Defined in
 
-[rawTypes.ts:36](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/rawTypes.ts#L36)
+[rawTypes.ts:36](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/rawTypes.ts#L36)

--- a/docs/reference/interfaces/RawCryptoOrgTransaction.md
+++ b/docs/reference/interfaces/RawCryptoOrgTransaction.md
@@ -30,7 +30,7 @@
 
 #### Defined in
 
-[rawTypes.ts:35](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/rawTypes.ts#L35)
+[rawTypes.ts:35](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/rawTypes.ts#L35)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[families/crypto_org/types.ts:15](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/crypto_org/types.ts#L15)
+[families/crypto_org/types.ts:15](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/crypto_org/types.ts#L15)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[families/crypto_org/types.ts:17](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/crypto_org/types.ts#L17)
+[families/crypto_org/types.ts:17](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/crypto_org/types.ts#L17)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[families/crypto_org/types.ts:16](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/crypto_org/types.ts#L16)
+[families/crypto_org/types.ts:16](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/crypto_org/types.ts#L16)
 
 ___
 
@@ -78,4 +78,4 @@ ___
 
 #### Defined in
 
-[rawTypes.ts:36](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/rawTypes.ts#L36)
+[rawTypes.ts:36](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/rawTypes.ts#L36)

--- a/docs/reference/interfaces/RawEthereumTransaction.md
+++ b/docs/reference/interfaces/RawEthereumTransaction.md
@@ -32,7 +32,7 @@
 
 #### Defined in
 
-[rawTypes.ts:35](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/rawTypes.ts#L35)
+[rawTypes.ts:35](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/rawTypes.ts#L35)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[families/ethereum/types.ts:19](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/ethereum/types.ts#L19)
+[families/ethereum/types.ts:19](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/ethereum/types.ts#L19)
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-[families/ethereum/types.ts:17](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/ethereum/types.ts#L17)
+[families/ethereum/types.ts:17](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/ethereum/types.ts#L17)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[families/ethereum/types.ts:21](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/ethereum/types.ts#L21)
+[families/ethereum/types.ts:21](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/ethereum/types.ts#L21)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[families/ethereum/types.ts:20](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/ethereum/types.ts#L20)
+[families/ethereum/types.ts:20](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/ethereum/types.ts#L20)
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[families/ethereum/types.ts:18](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/ethereum/types.ts#L18)
+[families/ethereum/types.ts:18](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/ethereum/types.ts#L18)
 
 ___
 
@@ -100,4 +100,4 @@ ___
 
 #### Defined in
 
-[rawTypes.ts:36](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/rawTypes.ts#L36)
+[rawTypes.ts:36](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/rawTypes.ts#L36)

--- a/docs/reference/interfaces/RawPolkadotTransaction.md
+++ b/docs/reference/interfaces/RawPolkadotTransaction.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[rawTypes.ts:35](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/rawTypes.ts#L35)
+[rawTypes.ts:35](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/rawTypes.ts#L35)
 
 ___
 
@@ -41,7 +41,7 @@ ___
 
 #### Defined in
 
-[families/polkadot/types.ts:30](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/polkadot/types.ts#L30)
+[families/polkadot/types.ts:30](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/polkadot/types.ts#L30)
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 #### Defined in
 
-[families/polkadot/types.ts:27](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/polkadot/types.ts#L27)
+[families/polkadot/types.ts:27](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/polkadot/types.ts#L27)
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 #### Defined in
 
-[families/polkadot/types.ts:29](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/polkadot/types.ts#L29)
+[families/polkadot/types.ts:29](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/polkadot/types.ts#L29)
 
 ___
 
@@ -75,7 +75,7 @@ ___
 
 #### Defined in
 
-[families/polkadot/types.ts:28](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/polkadot/types.ts#L28)
+[families/polkadot/types.ts:28](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/polkadot/types.ts#L28)
 
 ___
 
@@ -89,4 +89,4 @@ ___
 
 #### Defined in
 
-[rawTypes.ts:36](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/rawTypes.ts#L36)
+[rawTypes.ts:36](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/rawTypes.ts#L36)

--- a/docs/reference/interfaces/RawRippleTransaction.md
+++ b/docs/reference/interfaces/RawRippleTransaction.md
@@ -30,7 +30,7 @@
 
 #### Defined in
 
-[rawTypes.ts:35](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/rawTypes.ts#L35)
+[rawTypes.ts:35](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/rawTypes.ts#L35)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[families/ripple/types.ts:15](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/ripple/types.ts#L15)
+[families/ripple/types.ts:15](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/ripple/types.ts#L15)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[families/ripple/types.ts:16](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/ripple/types.ts#L16)
+[families/ripple/types.ts:16](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/ripple/types.ts#L16)
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 #### Defined in
 
-[rawTypes.ts:36](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/rawTypes.ts#L36)
+[rawTypes.ts:36](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/rawTypes.ts#L36)
 
 ___
 
@@ -78,4 +78,4 @@ ___
 
 #### Defined in
 
-[families/ripple/types.ts:17](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/ripple/types.ts#L17)
+[families/ripple/types.ts:17](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/ripple/types.ts#L17)

--- a/docs/reference/interfaces/RawStellarTransaction.md
+++ b/docs/reference/interfaces/RawStellarTransaction.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[rawTypes.ts:35](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/rawTypes.ts#L35)
+[rawTypes.ts:35](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/rawTypes.ts#L35)
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 #### Defined in
 
-[families/stellar/types.ts:16](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/stellar/types.ts#L16)
+[families/stellar/types.ts:16](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/stellar/types.ts#L16)
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 #### Defined in
 
-[families/stellar/types.ts:17](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/stellar/types.ts#L17)
+[families/stellar/types.ts:17](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/stellar/types.ts#L17)
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 #### Defined in
 
-[families/stellar/types.ts:18](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/stellar/types.ts#L18)
+[families/stellar/types.ts:18](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/stellar/types.ts#L18)
 
 ___
 
@@ -75,7 +75,7 @@ ___
 
 #### Defined in
 
-[families/stellar/types.ts:19](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/stellar/types.ts#L19)
+[families/stellar/types.ts:19](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/stellar/types.ts#L19)
 
 ___
 
@@ -89,4 +89,4 @@ ___
 
 #### Defined in
 
-[rawTypes.ts:36](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/rawTypes.ts#L36)
+[rawTypes.ts:36](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/rawTypes.ts#L36)

--- a/docs/reference/interfaces/RawTezosTransaction.md
+++ b/docs/reference/interfaces/RawTezosTransaction.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[rawTypes.ts:35](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/rawTypes.ts#L35)
+[rawTypes.ts:35](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/rawTypes.ts#L35)
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 #### Defined in
 
-[families/tezos/types.ts:18](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/tezos/types.ts#L18)
+[families/tezos/types.ts:18](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/tezos/types.ts#L18)
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 #### Defined in
 
-[families/tezos/types.ts:20](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/tezos/types.ts#L20)
+[families/tezos/types.ts:20](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/tezos/types.ts#L20)
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 #### Defined in
 
-[families/tezos/types.ts:21](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/tezos/types.ts#L21)
+[families/tezos/types.ts:21](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/tezos/types.ts#L21)
 
 ___
 
@@ -75,7 +75,7 @@ ___
 
 #### Defined in
 
-[families/tezos/types.ts:19](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/tezos/types.ts#L19)
+[families/tezos/types.ts:19](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/tezos/types.ts#L19)
 
 ___
 
@@ -89,4 +89,4 @@ ___
 
 #### Defined in
 
-[rawTypes.ts:36](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/rawTypes.ts#L36)
+[rawTypes.ts:36](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/rawTypes.ts#L36)

--- a/docs/reference/interfaces/RawTransactionCommon.md
+++ b/docs/reference/interfaces/RawTransactionCommon.md
@@ -46,7 +46,7 @@ The raw representation of the common transaction fields found in [TransactionCom
 
 #### Defined in
 
-[rawTypes.ts:35](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/rawTypes.ts#L35)
+[rawTypes.ts:35](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/rawTypes.ts#L35)
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-[rawTypes.ts:34](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/rawTypes.ts#L34)
+[rawTypes.ts:34](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/rawTypes.ts#L34)
 
 ___
 
@@ -66,4 +66,4 @@ ___
 
 #### Defined in
 
-[rawTypes.ts:36](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/rawTypes.ts#L36)
+[rawTypes.ts:36](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/rawTypes.ts#L36)

--- a/docs/reference/interfaces/RawTronTransaction.md
+++ b/docs/reference/interfaces/RawTronTransaction.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[rawTypes.ts:35](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/rawTypes.ts#L35)
+[rawTypes.ts:35](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/rawTypes.ts#L35)
 
 ___
 
@@ -41,7 +41,7 @@ ___
 
 #### Defined in
 
-[families/tron/types.ts:26](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/tron/types.ts#L26)
+[families/tron/types.ts:26](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/tron/types.ts#L26)
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 #### Defined in
 
-[families/tron/types.ts:23](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/tron/types.ts#L23)
+[families/tron/types.ts:23](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/tron/types.ts#L23)
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 #### Defined in
 
-[families/tron/types.ts:24](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/tron/types.ts#L24)
+[families/tron/types.ts:24](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/tron/types.ts#L24)
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 #### Defined in
 
-[rawTypes.ts:36](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/rawTypes.ts#L36)
+[rawTypes.ts:36](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/rawTypes.ts#L36)
 
 ___
 
@@ -89,4 +89,4 @@ ___
 
 #### Defined in
 
-[families/tron/types.ts:25](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/tron/types.ts#L25)
+[families/tron/types.ts:25](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/tron/types.ts#L25)

--- a/docs/reference/interfaces/RippleTransaction.md
+++ b/docs/reference/interfaces/RippleTransaction.md
@@ -33,7 +33,7 @@ For example in BTC, a tx with an 'amount' field of 1 will correspond to a tx cor
 
 #### Defined in
 
-[types.ts:92](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L92)
+[types.ts:92](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L92)
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 #### Defined in
 
-[families/ripple/types.ts:9](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/ripple/types.ts#L9)
+[families/ripple/types.ts:9](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/ripple/types.ts#L9)
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 #### Defined in
 
-[families/ripple/types.ts:10](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/ripple/types.ts#L10)
+[families/ripple/types.ts:10](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/ripple/types.ts#L10)
 
 ___
 
@@ -69,7 +69,7 @@ The address of the transaction's recipient
 
 #### Defined in
 
-[types.ts:96](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L96)
+[types.ts:96](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L96)
 
 ___
 
@@ -79,4 +79,4 @@ ___
 
 #### Defined in
 
-[families/ripple/types.ts:11](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/ripple/types.ts#L11)
+[families/ripple/types.ts:11](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/ripple/types.ts#L11)

--- a/docs/reference/interfaces/StellarTransaction.md
+++ b/docs/reference/interfaces/StellarTransaction.md
@@ -34,7 +34,7 @@ For example in BTC, a tx with an 'amount' field of 1 will correspond to a tx cor
 
 #### Defined in
 
-[types.ts:92](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L92)
+[types.ts:92](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L92)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[families/stellar/types.ts:9](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/stellar/types.ts#L9)
+[families/stellar/types.ts:9](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/stellar/types.ts#L9)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[families/stellar/types.ts:10](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/stellar/types.ts#L10)
+[families/stellar/types.ts:10](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/stellar/types.ts#L10)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[families/stellar/types.ts:11](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/stellar/types.ts#L11)
+[families/stellar/types.ts:11](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/stellar/types.ts#L11)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[families/stellar/types.ts:12](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/stellar/types.ts#L12)
+[families/stellar/types.ts:12](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/stellar/types.ts#L12)
 
 ___
 
@@ -90,4 +90,4 @@ The address of the transaction's recipient
 
 #### Defined in
 
-[types.ts:96](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L96)
+[types.ts:96](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L96)

--- a/docs/reference/interfaces/TezosTransaction.md
+++ b/docs/reference/interfaces/TezosTransaction.md
@@ -34,7 +34,7 @@ For example in BTC, a tx with an 'amount' field of 1 will correspond to a tx cor
 
 #### Defined in
 
-[types.ts:92](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L92)
+[types.ts:92](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L92)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[families/tezos/types.ts:11](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/tezos/types.ts#L11)
+[families/tezos/types.ts:11](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/tezos/types.ts#L11)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[families/tezos/types.ts:13](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/tezos/types.ts#L13)
+[families/tezos/types.ts:13](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/tezos/types.ts#L13)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[families/tezos/types.ts:14](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/tezos/types.ts#L14)
+[families/tezos/types.ts:14](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/tezos/types.ts#L14)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[families/tezos/types.ts:12](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/tezos/types.ts#L12)
+[families/tezos/types.ts:12](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/tezos/types.ts#L12)
 
 ___
 
@@ -90,4 +90,4 @@ The address of the transaction's recipient
 
 #### Defined in
 
-[types.ts:96](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L96)
+[types.ts:96](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L96)

--- a/docs/reference/interfaces/TransactionCommon.md
+++ b/docs/reference/interfaces/TransactionCommon.md
@@ -46,7 +46,7 @@ For example in BTC, a tx with an 'amount' field of 1 will correspond to a tx cor
 
 #### Defined in
 
-[types.ts:92](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L92)
+[types.ts:92](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L92)
 
 ___
 
@@ -58,4 +58,4 @@ The address of the transaction's recipient
 
 #### Defined in
 
-[types.ts:96](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L96)
+[types.ts:96](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L96)

--- a/docs/reference/interfaces/Transport.md
+++ b/docs/reference/interfaces/Transport.md
@@ -32,7 +32,7 @@ A function to handle new messages coming from the Ledger Live platform
 
 #### Defined in
 
-[types.ts:37](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L37)
+[types.ts:37](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L37)
 
 ## Methods
 
@@ -48,7 +48,7 @@ Connect the transport instance
 
 #### Defined in
 
-[types.ts:29](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L29)
+[types.ts:29](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L29)
 
 ___
 
@@ -64,7 +64,7 @@ Disconnect the transport instance
 
 #### Defined in
 
-[types.ts:33](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L33)
+[types.ts:33](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L33)
 
 ___
 
@@ -86,4 +86,4 @@ A function to send new messages to the Ledger Live platform
 
 #### Defined in
 
-[types.ts:41](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L41)
+[types.ts:41](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L41)

--- a/docs/reference/interfaces/TronTransaction.md
+++ b/docs/reference/interfaces/TronTransaction.md
@@ -34,7 +34,7 @@ For example in BTC, a tx with an 'amount' field of 1 will correspond to a tx cor
 
 #### Defined in
 
-[types.ts:92](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L92)
+[types.ts:92](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L92)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[families/tron/types.ts:19](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/tron/types.ts#L19)
+[families/tron/types.ts:19](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/tron/types.ts#L19)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[families/tron/types.ts:16](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/tron/types.ts#L16)
+[families/tron/types.ts:16](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/tron/types.ts#L16)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[families/tron/types.ts:17](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/tron/types.ts#L17)
+[families/tron/types.ts:17](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/tron/types.ts#L17)
 
 ___
 
@@ -80,7 +80,7 @@ The address of the transaction's recipient
 
 #### Defined in
 
-[types.ts:96](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L96)
+[types.ts:96](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L96)
 
 ___
 
@@ -90,4 +90,4 @@ ___
 
 #### Defined in
 
-[families/tron/types.ts:18](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/tron/types.ts#L18)
+[families/tron/types.ts:18](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/tron/types.ts#L18)

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -106,7 +106,7 @@ This is a slightly modified subset of the Account type used by the Ledger Live p
 
 #### Defined in
 
-[types.ts:162](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L162)
+[types.ts:162](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L162)
 
 ___
 
@@ -116,7 +116,7 @@ ___
 
 #### Defined in
 
-[families/algorand/types.ts:8](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/algorand/types.ts#L8)
+[families/algorand/types.ts:8](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/algorand/types.ts#L8)
 
 ___
 
@@ -135,7 +135,7 @@ Informations about a device application
 
 #### Defined in
 
-[types.ts:200](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L200)
+[types.ts:200](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L200)
 
 ___
 
@@ -157,7 +157,7 @@ Base currency model
 
 #### Defined in
 
-[types.ts:237](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L237)
+[types.ts:237](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L237)
 
 ___
 
@@ -167,7 +167,7 @@ ___
 
 #### Defined in
 
-[families/cosmos/types.ts:8](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/cosmos/types.ts#L8)
+[families/cosmos/types.ts:8](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/cosmos/types.ts#L8)
 
 ___
 
@@ -179,7 +179,7 @@ Crypto currency model
 
 #### Defined in
 
-[types.ts:263](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L263)
+[types.ts:263](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L263)
 
 ___
 
@@ -189,7 +189,7 @@ ___
 
 #### Defined in
 
-[types.ts:304](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L304)
+[types.ts:304](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L304)
 
 ___
 
@@ -208,7 +208,7 @@ Information about a device
 
 #### Defined in
 
-[types.ts:134](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L134)
+[types.ts:134](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L134)
 
 ___
 
@@ -220,7 +220,7 @@ ERC20 token currency model
 
 #### Defined in
 
-[types.ts:293](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L293)
+[types.ts:293](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L293)
 
 ___
 
@@ -232,7 +232,7 @@ The ECDSA signature of the [payload](modules.md#exchangepayload)
 
 #### Defined in
 
-[types.ts:53](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L53)
+[types.ts:53](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L53)
 
 ___
 
@@ -244,7 +244,7 @@ A transaction ID used to complete the exchange process
 
 #### Defined in
 
-[types.ts:58](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L58)
+[types.ts:58](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L58)
 
 ___
 
@@ -259,7 +259,7 @@ and a partner (for sell, swap and funding)
 
 #### Defined in
 
-[types.ts:48](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L48)
+[types.ts:48](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L48)
 
 ___
 
@@ -287,7 +287,7 @@ Simple contract for handling a Message received through a [Transport](interfaces
 
 #### Defined in
 
-[types.ts:18](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L18)
+[types.ts:18](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L18)
 
 ___
 
@@ -297,7 +297,7 @@ ___
 
 #### Defined in
 
-[families/polkadot/types.ts:8](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/polkadot/types.ts#L8)
+[families/polkadot/types.ts:8](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/polkadot/types.ts#L8)
 
 ___
 
@@ -324,7 +324,7 @@ The raw representation of the [Account](modules.md#account) type
 
 #### Defined in
 
-[rawTypes.ts:17](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/rawTypes.ts#L17)
+[rawTypes.ts:17](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/rawTypes.ts#L17)
 
 ___
 
@@ -348,7 +348,7 @@ This type is returned by Ledger Live when signing with [signTransaction](classes
 
 #### Defined in
 
-[rawTypes.ts:60](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/rawTypes.ts#L60)
+[rawTypes.ts:60](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/rawTypes.ts#L60)
 
 ___
 
@@ -360,7 +360,7 @@ The raw representation of the generic [Transaction](modules.md#transaction) type
 
 #### Defined in
 
-[rawTypes.ts:42](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/rawTypes.ts#L42)
+[rawTypes.ts:42](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/rawTypes.ts#L42)
 
 ___
 
@@ -370,7 +370,7 @@ ___
 
 #### Defined in
 
-[families/tezos/types.ts:8](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/tezos/types.ts#L8)
+[families/tezos/types.ts:8](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/tezos/types.ts#L8)
 
 ___
 
@@ -382,7 +382,7 @@ Token currency model
 
 #### Defined in
 
-[types.ts:278](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L278)
+[types.ts:278](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L278)
 
 ___
 
@@ -396,7 +396,7 @@ them to the network upon user validation.
 
 #### Defined in
 
-[types.ts:104](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L104)
+[types.ts:104](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L104)
 
 ___
 
@@ -406,7 +406,7 @@ ___
 
 #### Defined in
 
-[families/tron/types.ts:6](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/tron/types.ts#L6)
+[families/tron/types.ts:6](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/tron/types.ts#L6)
 
 ___
 
@@ -416,7 +416,7 @@ ___
 
 #### Defined in
 
-[families/tron/types.ts:13](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/families/tron/types.ts#L13)
+[families/tron/types.ts:13](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/tron/types.ts#L13)
 
 ___
 
@@ -441,7 +441,7 @@ This is a slightly modified subset of the Unit type used by the Ledger Live plat
 
 #### Defined in
 
-[types.ts:219](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/types.ts#L219)
+[types.ts:219](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/types.ts#L219)
 
 ## Functions
 
@@ -466,7 +466,7 @@ The object account of the provided raw account representation
 
 #### Defined in
 
-[serializers.ts:84](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/serializers.ts#L84)
+[serializers.ts:84](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/serializers.ts#L84)
 
 ___
 
@@ -491,7 +491,7 @@ The object transaction of the provided raw transaction representation
 
 #### Defined in
 
-[serializers.ts:147](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/serializers.ts#L147)
+[serializers.ts:147](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/serializers.ts#L147)
 
 ___
 
@@ -516,7 +516,7 @@ The raw representation of the provided account object
 
 #### Defined in
 
-[serializers.ts:55](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/serializers.ts#L55)
+[serializers.ts:55](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/serializers.ts#L55)
 
 ___
 
@@ -541,4 +541,4 @@ The raw representation of the provided transaction object
 
 #### Defined in
 
-[serializers.ts:113](https://github.com/LedgerHQ/live-app-sdk/blob/5608a83/src/serializers.ts#L113)
+[serializers.ts:113](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/serializers.ts#L113)

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "prepare": "yarn build && husky install",
     "build": "tsc -p tsconfig.prod.json",
     "test": "nyc mocha",
-    "doc": "typedoc --out docs/reference src/index.ts",
-    "doc:html": "typedoc --out docs/html --plugin typedoc-plugin-rename-defaults --plugin typedoc-plugin-param-names src/index.ts"
+    "doc": "typedoc --gitRevision main --out docs/reference src/index.ts",
+    "doc:html": "typedoc --gitRevision main --out docs/html --plugin typedoc-plugin-rename-defaults --plugin typedoc-plugin-param-names src/index.ts"
   },
   "dependencies": {
     "bignumber.js": "^9.0.2",


### PR DESCRIPTION
This PR aims to enforce doc update in order to keep the documentation up to date with the implementation for each change.

It adds a step in the CI to test if the doc is up to date.
The `typedoc` command is also run with the `--gitRevision` option set to `main` (cf. [this comment](https://github.com/TypeStrong/typedoc/issues/1488#issuecomment-770116706)) to avoid large diff spam due to changing commit-hash.

This solution has been chosen rather than a new github action that would automatically update and commit the doc to reduce overall complexity and allow more granularity on the developer side.
This solution feels like a good and balanced fit for our current needs.

We could still decide to automate this even more at a later date if need be.

cf. https://ledgerhq.atlassian.net/browse/LIVE-779