### PR TITLE
feat: Add simple store interface

### DIFF
--- a/docs/reference/classes/LedgerLivePlatformSDK.md
+++ b/docs/reference/classes/LedgerLivePlatformSDK.md
@@ -84,7 +84,7 @@ ___
 
 ### \_saveToStorage
 
-▸ **_saveToStorage**(`key`, `value`): `Promise`<`void`\>
+▸ **_saveToStorage**(`key`, `value`): `Promise`<`boolean`\>
 
 PRIVATE METHOD.
 Save `value` into the storage provided by the Wallet Server.
@@ -98,7 +98,7 @@ Save `value` into the storage provided by the Wallet Server.
 
 #### Returns
 
-`Promise`<`void`\>
+`Promise`<`boolean`\>
 
 Nothing
 

--- a/docs/reference/classes/LedgerLivePlatformSDK.md
+++ b/docs/reference/classes/LedgerLivePlatformSDK.md
@@ -8,8 +8,14 @@
 
 - [constructor](LedgerLivePlatformSDK.md#constructor)
 
+### Properties
+
+- [storage](LedgerLivePlatformSDK.md#storage)
+
 ### Methods
 
+- [\_getFromStorage](LedgerLivePlatformSDK.md#_getfromstorage)
+- [\_saveToStorage](LedgerLivePlatformSDK.md#_savetostorage)
 - [broadcastSignedTransaction](LedgerLivePlatformSDK.md#broadcastsignedtransaction)
 - [completeExchange](LedgerLivePlatformSDK.md#completeexchange)
 - [connect](LedgerLivePlatformSDK.md#connect)
@@ -37,9 +43,70 @@
 
 #### Defined in
 
-[LedgerLivePlatformSDK/index.ts:54](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L54)
+[LedgerLivePlatformSDK/index.ts:57](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L57)
+
+## Properties
+
+### storage
+
+• `Readonly` **storage**: `StorageSDK`
+
+#### Defined in
+
+[LedgerLivePlatformSDK/index.ts:55](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L55)
 
 ## Methods
+
+### \_getFromStorage
+
+▸ **_getFromStorage**(`key`): `Promise`<`string`\>
+
+PRIVATE METHOD.
+Retrieve the value associated with the `key` from the storage provided by the Wallet Server.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `key` | `string` | key associated to searched value |
+
+#### Returns
+
+`Promise`<`string`\>
+
+The value associated to the `key`
+
+#### Defined in
+
+[LedgerLivePlatformSDK/index.ts:394](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L394)
+
+___
+
+### \_saveToStorage
+
+▸ **_saveToStorage**(`key`, `value`): `Promise`<`void`\>
+
+PRIVATE METHOD.
+Save `value` into the storage provided by the Wallet Server.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `key` | `string` | key to find later the value |
+| `value` | `string` | value to save |
+
+#### Returns
+
+`Promise`<`void`\>
+
+Nothing
+
+#### Defined in
+
+[LedgerLivePlatformSDK/index.ts:384](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L384)
+
+___
 
 ### broadcastSignedTransaction
 
@@ -62,7 +129,7 @@ The hash of the transaction
 
 #### Defined in
 
-[LedgerLivePlatformSDK/index.ts:247](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L247)
+[LedgerLivePlatformSDK/index.ts:254](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L254)
 
 ___
 
@@ -97,7 +164,7 @@ If the exchange is validated, the transaction is then signed and broadcasted to 
 
 #### Defined in
 
-[LedgerLivePlatformSDK/index.ts:165](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L165)
+[LedgerLivePlatformSDK/index.ts:172](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L172)
 
 ___
 
@@ -116,7 +183,7 @@ Establish the connection with Ledger Live through the [[transport]] instance pro
 
 #### Defined in
 
-[LedgerLivePlatformSDK/index.ts:90](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L90)
+[LedgerLivePlatformSDK/index.ts:97](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L97)
 
 ___
 
@@ -132,7 +199,7 @@ Disconnect the SDK.
 
 #### Defined in
 
-[LedgerLivePlatformSDK/index.ts:106](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L106)
+[LedgerLivePlatformSDK/index.ts:113](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L113)
 
 ___
 
@@ -157,7 +224,7 @@ The list of accounts added by the current user on Ledger Live
 
 #### Defined in
 
-[LedgerLivePlatformSDK/index.ts:262](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L262)
+[LedgerLivePlatformSDK/index.ts:269](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L269)
 
 ___
 
@@ -185,7 +252,7 @@ The list of corresponding cryptocurrencies
 
 #### Defined in
 
-[LedgerLivePlatformSDK/index.ts:337](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L337)
+[LedgerLivePlatformSDK/index.ts:344](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L344)
 
 ___
 
@@ -209,7 +276,7 @@ The verified address or an error message if the verification doesn't succeed
 
 #### Defined in
 
-[LedgerLivePlatformSDK/index.ts:313](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L313)
+[LedgerLivePlatformSDK/index.ts:320](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L320)
 
 ___
 
@@ -236,7 +303,7 @@ The account selected by the user
 
 #### Defined in
 
-[LedgerLivePlatformSDK/index.ts:282](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L282)
+[LedgerLivePlatformSDK/index.ts:289](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L289)
 
 ___
 
@@ -262,7 +329,7 @@ Message signed
 
 #### Defined in
 
-[LedgerLivePlatformSDK/index.ts:233](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L233)
+[LedgerLivePlatformSDK/index.ts:240](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L240)
 
 ___
 
@@ -289,7 +356,7 @@ The raw signed transaction to broadcast
 
 #### Defined in
 
-[LedgerLivePlatformSDK/index.ts:208](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L208)
+[LedgerLivePlatformSDK/index.ts:215](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L215)
 
 ___
 
@@ -315,4 +382,4 @@ Start the exchange process by generating a nonce on Ledger device
 
 #### Defined in
 
-[LedgerLivePlatformSDK/index.ts:141](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L141)
+[LedgerLivePlatformSDK/index.ts:148](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/LedgerLivePlatformSDK/index.ts#L148)

--- a/docs/reference/classes/Mock.md
+++ b/docs/reference/classes/Mock.md
@@ -4,7 +4,7 @@
 
 ## Implements
 
-- `MockOf`<[`LedgerLivePlatformSDK`](LedgerLivePlatformSDK.md), ``"bridgeApp"`` \| ``"bridgeDashboard"`` \| ``"completeExchange"`` \| ``"startExchange"`` \| ``"listApps"`` \| ``"synchronizeAccount"`` \| ``"getLastConnectedDeviceInfo"``\>
+- `MockOf`<[`LedgerLivePlatformSDK`](LedgerLivePlatformSDK.md), ``"bridgeApp"`` \| ``"bridgeDashboard"`` \| ``"completeExchange"`` \| ``"startExchange"`` \| ``"listApps"`` \| ``"synchronizeAccount"`` \| ``"getLastConnectedDeviceInfo"`` \| ``"_saveToStorage"`` \| ``"_getFromStorage"``\>
 
 ## Table of contents
 
@@ -15,6 +15,7 @@
 ### Properties
 
 - [connected](Mock.md#connected)
+- [storage](Mock.md#storage)
 
 ### Methods
 
@@ -43,7 +44,21 @@
 
 #### Defined in
 
-[mock/index.ts:34](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L34)
+[mock/index.ts:37](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L37)
+
+___
+
+### storage
+
+• `Readonly` **storage**: `StorageSDK`
+
+#### Implementation of
+
+MockOf.storage
+
+#### Defined in
+
+[mock/index.ts:47](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L47)
 
 ## Methods
 
@@ -68,7 +83,7 @@ MockOf.broadcastSignedTransaction
 
 #### Defined in
 
-[mock/index.ts:113](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L113)
+[mock/index.ts:125](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L125)
 
 ___
 
@@ -86,7 +101,7 @@ MockOf.connect
 
 #### Defined in
 
-[mock/index.ts:36](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L36)
+[mock/index.ts:39](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L39)
 
 ___
 
@@ -104,7 +119,7 @@ MockOf.disconnect
 
 #### Defined in
 
-[mock/index.ts:40](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L40)
+[mock/index.ts:43](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L43)
 
 ___
 
@@ -124,7 +139,7 @@ ___
 
 #### Defined in
 
-[mock/index.ts:65](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L65)
+[mock/index.ts:77](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L77)
 
 ___
 
@@ -142,7 +157,7 @@ MockOf.listAccounts
 
 #### Defined in
 
-[mock/index.ts:58](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L58)
+[mock/index.ts:70](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L70)
 
 ___
 
@@ -160,7 +175,7 @@ MockOf.listCurrencies
 
 #### Defined in
 
-[mock/index.ts:50](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L50)
+[mock/index.ts:62](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L62)
 
 ___
 
@@ -184,7 +199,7 @@ MockOf.receive
 
 #### Defined in
 
-[mock/index.ts:79](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L79)
+[mock/index.ts:91](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L91)
 
 ___
 
@@ -204,7 +219,7 @@ MockOf.requestAccount
 
 #### Defined in
 
-[mock/index.ts:46](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L46)
+[mock/index.ts:58](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L58)
 
 ___
 
@@ -229,7 +244,7 @@ MockOf.signMessage
 
 #### Defined in
 
-[mock/index.ts:109](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L109)
+[mock/index.ts:121](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L121)
 
 ___
 
@@ -254,4 +269,4 @@ MockOf.signTransaction
 
 #### Defined in
 
-[mock/index.ts:94](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L94)
+[mock/index.ts:106](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/mock/index.ts#L106)

--- a/src/LedgerLivePlatformSDK/index.ts
+++ b/src/LedgerLivePlatformSDK/index.ts
@@ -29,6 +29,7 @@ import type {
 } from "../types";
 
 import LedgerPlatformApduTransport from "./LedgerPlatformApduTransport";
+import storageFactory, { StorageSDK } from "./storage";
 
 const defaultLogger = new Logger("LL-PlatformSDK");
 
@@ -51,9 +52,15 @@ export default class LedgerLivePlatformSDK {
    */
   private serverAndClient?: JSONRPCServerAndClient;
 
+  readonly storage: StorageSDK;
+
   constructor(transport: Transport, logger: Logger = defaultLogger) {
     this.transport = transport;
     this.logger = logger;
+    this.storage = storageFactory({
+      saveToStorage: this._saveToStorage.bind(this),
+      getFromStorage: this._getFromStorage.bind(this),
+    });
   }
 
   /**
@@ -365,5 +372,26 @@ export default class LedgerLivePlatformSDK {
    */
   async listApps(): Promise<ApplicationDetails[]> {
     throw new Error("Function is not implemented yet");
+  }
+
+  /**
+   * PRIVATE METHOD.
+   * Save `value` into the storage provided by the Wallet Server.
+   * @param key - key to find later the value
+   * @param value - value to save
+   * @returns Nothing
+   */
+  async _saveToStorage(key: string, value: string): Promise<void> {
+    return this._request("storage.set", { key, value });
+  }
+
+  /**
+   * PRIVATE METHOD.
+   * Retrieve the value associated with the `key` from the storage provided by the Wallet Server.
+   * @param key - key associated to searched value
+   * @returns The value associated to the `key`
+   */
+  async _getFromStorage(key: string): Promise<string> {
+    return this._request("storage.get", { key });
   }
 }

--- a/src/LedgerLivePlatformSDK/index.ts
+++ b/src/LedgerLivePlatformSDK/index.ts
@@ -381,7 +381,7 @@ export default class LedgerLivePlatformSDK {
    * @param value - value to save
    * @returns Nothing
    */
-  async _saveToStorage(key: string, value: string): Promise<void> {
+  async _saveToStorage(key: string, value: string): Promise<boolean> {
     return this._request("storage.set", { key, value });
   }
 

--- a/src/LedgerLivePlatformSDK/storage.ts
+++ b/src/LedgerLivePlatformSDK/storage.ts
@@ -6,9 +6,9 @@ export interface StorageSDK {
    * Store the value with the associated key.
    * @param key - Key to find later the value
    * @param value - Value to save
-   * @throws Will throw an error if the value has not been saved.
+   * @returns The false if the value has not been saved.
    */
-  save(key: string, value: string): Promise<void>;
+  save(key: string, value: string): Promise<boolean>;
   /**
    * Retrieve the value associated to the key.
    * @param key - Key linked to the value searched
@@ -18,7 +18,7 @@ export interface StorageSDK {
 }
 
 type StoreWrapper = {
-  saveToStorage: (key: string, value: string) => Promise<void>;
+  saveToStorage: (key: string, value: string) => Promise<boolean>;
   getFromStorage: (key: string) => Promise<string>;
 };
 
@@ -29,8 +29,8 @@ class DefaultStorageSDK implements StorageSDK {
     this.wrapper = wrapper;
   }
 
-  async save(key: string, value: string): Promise<void> {
-    await this.wrapper.saveToStorage(key, value);
+  async save(key: string, value: string): Promise<boolean> {
+    return this.wrapper.saveToStorage(key, value);
   }
 
   async get(key: string): Promise<string> {

--- a/src/LedgerLivePlatformSDK/storage.ts
+++ b/src/LedgerLivePlatformSDK/storage.ts
@@ -1,0 +1,47 @@
+/**
+ * Storage interface to access Wallet Server store.
+ */
+export interface StorageSDK {
+  /**
+   * Store the value with the associated key.
+   * @param key - Key to find later the value
+   * @param value - Value to save
+   */
+  save(key: string, value: string): Promise<void>;
+  /**
+   * Retrieve the value associated to the key.
+   * @param key - Key linked to the value searched
+   * @returns The value associated to the `key`
+   */
+  get(key: string): Promise<string>;
+}
+
+type StoreWrapper = {
+  saveToStorage: (key: string, value: string) => Promise<void>;
+  getFromStorage: (key: string) => Promise<string>;
+};
+
+class DefaultStorageSDK implements StorageSDK {
+  private wrapper: StoreWrapper;
+
+  constructor(wrapper: StoreWrapper) {
+    this.wrapper = wrapper;
+  }
+
+  async save(key: string, value: string): Promise<void> {
+    await this.wrapper.saveToStorage(key, value);
+  }
+
+  async get(key: string): Promise<string> {
+    return this.wrapper.getFromStorage(key);
+  }
+}
+
+/**
+ * Create a Storage object
+ * @param wrapper - Wrapper providing access method to a storage implementation
+ * @returns An object to interact with underlying storage system.
+ */
+export default function storeFactory(wrapper: StoreWrapper): StorageSDK {
+  return new DefaultStorageSDK(wrapper);
+}

--- a/src/LedgerLivePlatformSDK/storage.ts
+++ b/src/LedgerLivePlatformSDK/storage.ts
@@ -6,7 +6,7 @@ export interface StorageSDK {
    * Store the value with the associated key.
    * @param key - Key to find later the value
    * @param value - Value to save
-   * @returns The false if the value has not been saved.
+   * @returns `false` if the value has not been saved.
    */
   save(key: string, value: string): Promise<boolean>;
   /**

--- a/src/LedgerLivePlatformSDK/storage.ts
+++ b/src/LedgerLivePlatformSDK/storage.ts
@@ -6,6 +6,7 @@ export interface StorageSDK {
    * Store the value with the associated key.
    * @param key - Key to find later the value
    * @param value - Value to save
+   * @throws Will throw an error if the value has not been saved.
    */
   save(key: string, value: string): Promise<void>;
   /**

--- a/src/mock/index.ts
+++ b/src/mock/index.ts
@@ -45,8 +45,8 @@ export default class LedgerLiveSDKMock
   }
 
   readonly storage: StorageSDK = {
-    save: async (_key: string, _value: string): Promise<void> => {
-      await Promise.resolve("");
+    save: async (_key: string, _value: string): Promise<boolean> => {
+      return Promise.resolve(true);
     },
     get: async (_key: string): Promise<string> => {
       return Promise.resolve("");

--- a/src/mock/index.ts
+++ b/src/mock/index.ts
@@ -5,6 +5,7 @@ import type { Account, Currency } from "../types";
 import { deserializeAccount } from "../serializers";
 import LedgerLivePlatformSDK from "../LedgerLivePlatformSDK";
 import { RawSignedTransaction } from "../rawTypes";
+import { StorageSDK } from "../LedgerLivePlatformSDK/storage";
 
 const { rawAccounts, rawCurrencies } = data;
 
@@ -29,6 +30,8 @@ export default class LedgerLiveSDKMock
       | "listApps"
       | "synchronizeAccount"
       | "getLastConnectedDeviceInfo"
+      | "_saveToStorage"
+      | "_getFromStorage"
     >
 {
   connected = false;
@@ -40,6 +43,15 @@ export default class LedgerLiveSDKMock
   disconnect(): void {
     this.connected = false;
   }
+
+  readonly storage: StorageSDK = {
+    save: async (_key: string, _value: string): Promise<void> => {
+      await Promise.resolve("");
+    },
+    get: async (_key: string): Promise<string> => {
+      return Promise.resolve("");
+    },
+  };
 
   /** Legder Live Methods */
 

--- a/tests/unit/LedgerLivePlatformSDK/index.spec.ts
+++ b/tests/unit/LedgerLivePlatformSDK/index.spec.ts
@@ -493,6 +493,42 @@ describe("LedgerLivePlatformSDK/index.ts", () => {
         }
       });
     });
+
+    describe("_saveToStorage", () => {
+      it("should succeed to store a value", async () => {
+        SDK.connect();
+
+        const key = "someRandomKey";
+        const value = "someRandomValue";
+
+        const spy = createSpyOnPostMessage(true);
+
+        const res = await SDK._saveToStorage(key, value);
+
+        expect(res).to.eq(true);
+        expect(spy).to.have.been.called.with(
+          `{"jsonrpc":"2.0","method":"storage.set","params":{"key":"${key}","value":"${value}"},"id":1}`
+        );
+      });
+    });
+
+    describe("_getFromStorage", () => {
+      it("should succeed to get a value", async () => {
+        SDK.connect();
+
+        const key = "someRandomKey";
+        const value = "someRandomValue";
+
+        const spy = createSpyOnPostMessage(value);
+
+        const res = await SDK._getFromStorage(key);
+
+        expect(res).to.eq(value);
+        expect(spy).to.have.been.called.with(
+          `{"jsonrpc":"2.0","method":"storage.get","params":{"key":"${key}"},"id":1}`
+        );
+      });
+    });
   });
 
   describe("Missing implementations", () => {

--- a/tests/unit/LedgerLivePlatformSDK/storage.spec.ts
+++ b/tests/unit/LedgerLivePlatformSDK/storage.spec.ts
@@ -1,0 +1,52 @@
+import { expect } from "chai";
+import storeFactory from "../../../src/LedgerLivePlatformSDK/storage";
+
+describe("DefaultStorageSDK", () => {
+  class Wrapper {
+    keyStored = "";
+
+    valueStored = "";
+
+    saveToStorage(key: string, value: string): Promise<void> {
+      this.keyStored = key;
+      this.valueStored = value;
+      return Promise.resolve();
+    }
+
+    getFromStorage(key: string): Promise<string> {
+      this.keyStored = key;
+      return Promise.resolve(this.valueStored);
+    }
+  }
+
+  describe("save", () => {
+    it("call the wrapper method saveToStorage", async () => {
+      // Given
+      const wrapper = new Wrapper();
+      const defaultStorage = storeFactory(wrapper);
+
+      // When
+      await defaultStorage.save("Key to store", "Value to store");
+
+      // Then
+      expect(wrapper.keyStored).to.equals("Key to store");
+      expect(wrapper.valueStored).to.equals("Value to store");
+    });
+  });
+
+  describe("get", () => {
+    it("call the wrapper method getFromStorage", async () => {
+      // Given
+      const wrapper = new Wrapper();
+      wrapper.valueStored = "Value already stored";
+      const defaultStorage = storeFactory(wrapper);
+
+      // When
+      const value = await defaultStorage.get("Key to retrieve value");
+
+      // Then
+      expect(wrapper.keyStored).to.equals("Key to retrieve value");
+      expect(value).to.equals("Value already stored");
+    });
+  });
+});

--- a/tests/unit/LedgerLivePlatformSDK/storage.spec.ts
+++ b/tests/unit/LedgerLivePlatformSDK/storage.spec.ts
@@ -7,10 +7,10 @@ describe("DefaultStorageSDK", () => {
 
     valueStored = "";
 
-    saveToStorage(key: string, value: string): Promise<void> {
+    saveToStorage(key: string, value: string): Promise<boolean> {
       this.keyStored = key;
       this.valueStored = value;
-      return Promise.resolve();
+      return Promise.resolve(true);
     }
 
     getFromStorage(key: string): Promise<string> {


### PR DESCRIPTION
Add a simple interface to save and retrieve simple value.
Ticket related: [LIVE-4276](https://ledgerhq.atlassian.net/browse/LIVE-4276)

- https://github.com/LedgerHQ/ledger-live/pull/1604

Usage:
```ts
  liveSDK.storage.save("key", "Simple value");

  const value = await liveSDK.storage.get("key");
```