### PR TITLE
Add Stellar memoType enum

### DIFF
--- a/docs/reference/enums/StellarMemoType.md
+++ b/docs/reference/enums/StellarMemoType.md
@@ -1,0 +1,52 @@
+[@ledgerhq/live-app-sdk](../README.md) / [Exports](../modules.md) / StellarMemoType
+
+# Enumeration: StellarMemoType
+
+## Table of contents
+
+### Enumeration Members
+
+- [MEMO\_HASH](StellarMemoType.md#memo_hash)
+- [MEMO\_ID](StellarMemoType.md#memo_id)
+- [MEMO\_RETURN](StellarMemoType.md#memo_return)
+- [MEMO\_TEXT](StellarMemoType.md#memo_text)
+
+## Enumeration Members
+
+### MEMO\_HASH
+
+• **MEMO\_HASH**
+
+#### Defined in
+
+[families/stellar/types.ts:11](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/stellar/types.ts#L11)
+
+___
+
+### MEMO\_ID
+
+• **MEMO\_ID**
+
+#### Defined in
+
+[families/stellar/types.ts:10](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/stellar/types.ts#L10)
+
+___
+
+### MEMO\_RETURN
+
+• **MEMO\_RETURN**
+
+#### Defined in
+
+[families/stellar/types.ts:12](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/stellar/types.ts#L12)
+
+___
+
+### MEMO\_TEXT
+
+• **MEMO\_TEXT**
+
+#### Defined in
+
+[families/stellar/types.ts:9](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/stellar/types.ts#L9)

--- a/docs/reference/interfaces/RawStellarTransaction.md
+++ b/docs/reference/interfaces/RawStellarTransaction.md
@@ -45,7 +45,7 @@ ___
 
 #### Defined in
 
-[families/stellar/types.ts:16](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/stellar/types.ts#L16)
+[families/stellar/types.ts:23](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/stellar/types.ts#L23)
 
 ___
 
@@ -55,17 +55,17 @@ ___
 
 #### Defined in
 
-[families/stellar/types.ts:17](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/stellar/types.ts#L17)
+[families/stellar/types.ts:24](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/stellar/types.ts#L24)
 
 ___
 
 ### memoType
 
-• `Optional` **memoType**: `string`
+• `Optional` **memoType**: [`StellarMemoType`](../enums/StellarMemoType.md)
 
 #### Defined in
 
-[families/stellar/types.ts:18](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/stellar/types.ts#L18)
+[families/stellar/types.ts:25](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/stellar/types.ts#L25)
 
 ___
 
@@ -75,7 +75,7 @@ ___
 
 #### Defined in
 
-[families/stellar/types.ts:19](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/stellar/types.ts#L19)
+[families/stellar/types.ts:26](https://github.com/LedgerHQ/live-app-sdk/blob/main/src/families/stellar/types.ts#L26)
 
 ___
 

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -11,6 +11,7 @@
 - [ExchangeType](enums/ExchangeType.md)
 - [FAMILIES](enums/FAMILIES.md)
 - [FeesLevel](enums/FeesLevel.md)
+- [StellarMemoType](enums/StellarMemoType.md)
 - [TokenStandard](enums/TokenStandard.md)
 
 ### Classes

--- a/src/families/stellar/mocks.ts
+++ b/src/families/stellar/mocks.ts
@@ -1,7 +1,11 @@
 import BigNumber from "bignumber.js";
 import { rawTxCommon, txCommon } from "../../mock/transactionCommon";
 import FAMILIES from "../types";
-import { RawStellarTransaction, StellarTransaction } from "./types";
+import {
+  RawStellarTransaction,
+  StellarTransaction,
+  StellarMemoType,
+} from "./types";
 
 export const rawTx: RawStellarTransaction = {
   ...rawTxCommon,
@@ -11,7 +15,7 @@ export const rawTx: RawStellarTransaction = {
 export const rawTxFull: Required<RawStellarTransaction> = {
   ...rawTx,
   fees: "10",
-  memoType: "[MEMO-TYPE]",
+  memoType: StellarMemoType.MEMO_TEXT,
   memoValue: "[MEMO-VALUE]",
 };
 
@@ -23,6 +27,6 @@ export const tx: StellarTransaction = {
 export const txFull: Required<StellarTransaction> = {
   ...tx,
   fees: new BigNumber("10"),
-  memoType: "[MEMO-TYPE]",
+  memoType: StellarMemoType.MEMO_TEXT,
   memoValue: "[MEMO-VALUE]",
 };

--- a/src/families/stellar/types.ts
+++ b/src/families/stellar/types.ts
@@ -5,16 +5,23 @@ import FAMILIES from "../types";
 import type { RawTransactionCommon } from "../../rawTypes";
 import type { TransactionCommon } from "../../types";
 
+export enum StellarMemoType {
+  MEMO_TEXT = "MEMO_TEXT",
+  MEMO_ID = "MEMO_ID",
+  MEMO_HASH = "MEMO_HASH",
+  MEMO_RETURN = "MEMO_RETURN",
+}
+
 export interface StellarTransaction extends TransactionCommon {
   readonly family: FAMILIES.STELLAR;
   fees?: BigNumber;
-  memoType?: string;
+  memoType?: StellarMemoType;
   memoValue?: string;
 }
 
 export interface RawStellarTransaction extends RawTransactionCommon {
   readonly family: FAMILIES.STELLAR;
   fees?: string;
-  memoType?: string;
+  memoType?: StellarMemoType;
   memoValue?: string;
 }

--- a/tests/unit/serializers.spec.ts
+++ b/tests/unit/serializers.spec.ts
@@ -35,6 +35,7 @@ import {
 import {
   RawStellarTransaction,
   StellarTransaction,
+  StellarMemoType,
 } from "../../src/families/stellar/types";
 import {
   RawTezosTransaction,
@@ -409,7 +410,7 @@ describe("serializers.ts", () => {
         const transaction: StellarTransaction = {
           family: FAMILIES.STELLAR,
           fees: new BigNumber(1),
-          memoType: "memo type",
+          memoType: StellarMemoType.MEMO_TEXT,
           memoValue: "memo value",
           amount: new BigNumber(100),
           recipient: "recipient",
@@ -420,7 +421,7 @@ describe("serializers.ts", () => {
         expect(serializedTransaction).to.deep.eq({
           family: FAMILIES.STELLAR,
           fees: "1",
-          memoType: "memo type",
+          memoType: StellarMemoType.MEMO_TEXT,
           memoValue: "memo value",
           amount: "100",
           recipient: "recipient",
@@ -893,7 +894,7 @@ describe("serializers.ts", () => {
         const serializedTransaction: RawStellarTransaction = {
           family: FAMILIES.STELLAR,
           fees: "1",
-          memoType: "memo type",
+          memoType: StellarMemoType.MEMO_TEXT,
           memoValue: "memo value",
           amount: "100",
           recipient: "recipient",
@@ -906,7 +907,7 @@ describe("serializers.ts", () => {
         expect(transaction).to.deep.eq({
           family: FAMILIES.STELLAR,
           fees: new BigNumber(1),
-          memoType: "memo type",
+          memoType: StellarMemoType.MEMO_TEXT,
           memoValue: "memo value",
           amount: new BigNumber(100),
           recipient: "recipient",


### PR DESCRIPTION
**Changes**
Adds an enum with the valid values for a `StellarTransaction` `memoType` - replacing the current `string` type.

These can be located in the ledger-live js monorepo [here](https://github.com/LedgerHQ/ledger-live/blob/develop/libs/ledger-live-common/src/families/stellar/logic.ts#L249).

**Motivation**
I personally struggled to find the correct values to use here and ended up losing some test funds as a result.
Hopefully this inclusion can save future users some time.